### PR TITLE
Added import method for show from methods package.

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 useDynLib(RProtoBuf)
 
 importFrom(methods, new)
+importFrom(methods, show)
 importFrom(utils, str, packageDescription)
 importFrom(stats, update)
 importFrom(tools, file_path_as_absolute)


### PR DESCRIPTION
I believe this is a missing import that is necessary.  Otherwise, warnings result; see excerpt below.

```
> library(opencpu)
Initiating OpenCPU server...
Using config: /Users/naras/.opencpu.conf
Loading required package: survival
Loading required package: graphics
Loading required package: stats
Warning message:
no function found corresponding to methods exports from ‘RProtoBuf’ for: ‘show’ 
```