### PR TITLE
Feature/new travis -- with a proto v2/v3 matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,13 @@ env:
     # set up a test matrix for both ProtoBuf library versions: "v2" which we source
     # from Ubuntu "trusty" as usual, and "v3" which we source from Dirk's PPA where
     # an unofficial / local build of ProtoBuf 3.0.0 is available (sans Java)
-    - PROTO="v2"
-    - PROTO="v3"
+    - PROTOBUF="v2"
+    - PROTOBUF="v3"
   
 before_install:
   - curl -OLs http://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
-  # add our launchpad repo which has (inter alia) the newest QuantLib
-  # - sudo add-apt-repository -y ppa:edd/misc
+  # if v3, add our launchpad repo which has (inter alia) the newest ProtoBuf as an unofficial build
+  - if [ "$PROTOBUF" == "v3" ]; then sudo add-apt-repository -y ppa:edd/misc; fi
   - ./run.sh bootstrap
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,28 @@
-# Sample .travis.yml for R projects.
-#
-# See https://github.com/craigcitro/r-travis/wiki
-#     https://github.com/eddelbuettel/r-travis/
-
-sudo: required                                     
+# Run Travis CI for R using https://eddelbuettel.github.io/r-travis/
 
 language: c
 
+sudo: required
+
+dist: trusty
+
 before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
+  - curl -OLs http://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
+  # add our launchpad repo which has (inter alia) the newest QuantLib
+  # - sudo add-apt-repository -y ppa:edd/misc
+  - ./run.sh bootstrap
 
 install:
   - ./travis-tool.sh install_aptget libprotobuf-dev libprotoc-dev protobuf-compiler r-cran-rcpp r-cran-runit r-cran-rcurl r-cran-highlight
 
-script: 
-  - ./travis-tool.sh run_tests
+script:
+  - ./run.sh run_tests
 
 after_failure:
-  - ./travis-tool.sh dump_logs
+  - ./run.sh dump_logs
 
 notifications:
   email:
     on_success: change
     on_failure: change
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ sudo: required
 
 dist: trusty
 
+env:
+  matrix: 
+    # set up a test matrix for both ProtoBuf library versions: "v2" which we source
+    # from Ubuntu "trusty" as usual, and "v3" which we source from Dirk's PPA where
+    # an unofficial / local build of ProtoBuf 3.0.0 is available (sans Java)
+    - PROTO="v2"
+    - PROTO="v3"
+  
 before_install:
   - curl -OLs http://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
   # add our launchpad repo which has (inter alia) the newest QuantLib
@@ -13,7 +21,7 @@ before_install:
   - ./run.sh bootstrap
 
 install:
-  - .run.sh install_aptget libprotobuf-dev libprotoc-dev protobuf-compiler r-cran-rcpp r-cran-runit r-cran-rcurl r-cran-highlight
+  - ./run.sh install_aptget libprotobuf-dev libprotoc-dev protobuf-compiler r-cran-rcpp r-cran-runit r-cran-rcurl r-cran-highlight
 
 script:
   - ./run.sh run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - ./run.sh bootstrap
 
 install:
-  - ./travis-tool.sh install_aptget libprotobuf-dev libprotoc-dev protobuf-compiler r-cran-rcpp r-cran-runit r-cran-rcurl r-cran-highlight
+  - .run.sh install_aptget libprotobuf-dev libprotoc-dev protobuf-compiler r-cran-rcpp r-cran-runit r-cran-rcurl r-cran-highlight
 
 script:
   - ./run.sh run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   
 before_install:
   - curl -OLs http://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
-  # if v3, add our launchpad repo which has (inter alia) the newest ProtoBuf as an unofficial build
+  # if v3, add the launchpad repo which has (inter alia) the newest ProtoBuf as an unofficial build
   - if [ "$PROTOBUF" == "v3" ]; then sudo add-apt-repository -y ppa:edd/misc; fi
   - ./run.sh bootstrap
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-08-13  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .travis.yml: Switch to using run.sh for Travis CI
+
 2016-07-19  Craig Radcliffe  <chradcliffe@gmail.com>
 
 	* configure.in: Make sure that CXXFLAGS is from the environment

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2016-08-13  Dirk Eddelbuettel  <edd@debian.org>
 
-	* .travis.yml: Switch to using run.sh for Travis CI
+	* .travis.yml: Switch to using run.sh for Travis CI, also switch to
+	using a build matrix across ProtoBuf versions 2 and 3
 
 2016-07-19  Craig Radcliffe  <chradcliffe@gmail.com>
 


### PR DESCRIPTION
I switched to my maintained fork of the old r-travis setup (personal preference, mostly).

I also turned on a simple 'v2 versus v3' matrix.   I did setup builds of ProtoBuf 3.0.0 via Launchpad yesterday -- a bit of hack as I removed gmock (build complications) and Java (we don't need it).  I haven't really tested these packages but they should provide genuine ProtoBuf 3.0.0 for us.

So once the PR is in I'll a PR for the keywords