### PR TITLE
Ensure 0-length character vectors are correctly deserialized (closes #13)

### DIFF
--- a/R/rexp_obj.R
+++ b/R/rexp_obj.R
@@ -5,6 +5,11 @@
 # Modified 2014 by Murray Stokely to support language and environment types
 
 rexp_obj <- function(obj){
+  if(isS4(obj)) {
+    # Some S4 objects do not return "S4" from typeof.  e.g. lubridate interval
+    # These must be natively encoded or we will lose the S4 flag.
+    return(rexp_native(obj))
+  }
   sm <- typeof(obj);
   msg <- switch(sm,
     "character" = rexp_string(obj),

--- a/R/rexp_obj.R
+++ b/R/rexp_obj.R
@@ -103,7 +103,7 @@ unrexp_string <- function(myrexp){
   mystring <- unlist(lapply(myrexp$stringValue, "[[", "strval"))
   isNA <- unlist(lapply(myrexp$stringValue, "[[", "isNA"))
   mystring[isNA] <- NA
-  mystring
+  as.character(mystring)
 }
 
 unrexp_raw <- function(myrexp){
@@ -118,7 +118,7 @@ unrexp_complex <- function(myrexp){
   xvalue <- lapply(myrexp$complexValue, function(x){
     complex(real=x$real, imaginary=x$imag)
   })
-  unlist(xvalue)
+  as.complex(unlist(xvalue))
 }
 
 unrexp_integer <- function(myrexp){

--- a/inst/unitTests/runit.serialize_pb.R
+++ b/inst/unitTests/runit.serialize_pb.R
@@ -19,6 +19,7 @@ test.serialize_pb <- function() {
     mylist = list(foo='bar', 123, NA, NULL, list('test')),
     mylogical = c(TRUE,FALSE,NA),
     mychar = c('foo', NA, 'bar'),
+    myemptychar = character(0),
     somemissings = c(1,2,NA,NaN,5, Inf, 7 -Inf, 9, NA),
     myrawvec = charToRaw('This is a test')
   );

--- a/inst/unitTests/runit.serialize_pb.R
+++ b/inst/unitTests/runit.serialize_pb.R
@@ -21,7 +21,8 @@ test.serialize_pb <- function() {
     mychar = c('foo', NA, 'bar'),
     myemptychar = character(0),
     somemissings = c(1,2,NA,NaN,5, Inf, 7 -Inf, 9, NA),
-    myrawvec = charToRaw('This is a test')
+    myrawvec = charToRaw('This is a test'),
+    myS4 = asS4("test")
   );
 
   checkEquals(unserialize_pb(serialize_pb(myobject, NULL)), myobject)


### PR DESCRIPTION
unlist() will not give the vector the correct type when it is called on an empty list (see Issue #13).  This coerces the vectors to the correct type.  (This should also affect complex, so I applied the fix to it too.)