### PR TITLE
Feature/registration

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2017-03-05  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version and date
+
 	* src/init.c (R_init_RcppSMC): Call R_registerRoutines()
 	and R_useDynamicSymbols()
 
@@ -34,6 +36,10 @@
 	* m4/m4-ax_cxx_compile_stdcxx_0x.m4: Removed
 
 	* cleanup: remove autoconf cache
+
+2017-01-17  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Relase 0.4.8
 
 2017-01-16  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,24 @@
+2017-03-05  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/init.c (R_init_RcppSMC): Call R_registerRoutines()
+	and R_useDynamicSymbols()
+
+	* NAMESPACE: Use .registration=TRUE on useDynLib
+
+	* src/extensions.cpp (rprotobuf): Rename getExtension to
+	getExtension_cpp to disambiguate from R function
+	* src/rprotobuf.cpp (rprotobuf): Idem for readProtoFiles_cpp
+
+	* R/00classes.R (.icall): Comment-out unused function
+	(setMethod): Remove erroneous extra '...' from Message_clone arguments
+	* R/clone.R (._clone.message): Add missing PACKAGE= argument to .Call
+	* R/extensions.R: Idem
+	* R/has.R (._has_enum_name): Idem
+	* R/internals.R (readProtoFiles): Idem
+	* R/merge.R: Idem
+	* R/with.R (generateActiveBindings): Idem
+	* R/has.R (._has_enum_name): Use PACKAGE= in .Call()
+
 2017-01-19  Dirk Eddelbuettel  <edd@debian.org>
 
 	* configure.ac: Renamed from configure.in, minor edit

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RProtoBuf
-Version: 0.4.8
-Date: 2017-01-17
+Version: 0.4.8.2
+Date: 2017-03-05
 Author: Romain Francois, Dirk Eddelbuettel, Murray Stokely and Jeroen Ooms
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Title: R Interface to the 'Protocol Buffers' 'API' (Version 2 or 3)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,13 +1,13 @@
 
 ## Package has dynamic library
-useDynLib(RProtoBuf)
+useDynLib("RProtoBuf", .registration=TRUE)
 
-importFrom(methods, new, show, as, is)
-importFrom(utils, str, packageDescription)
-importFrom(stats, update)
-importFrom(tools, file_path_as_absolute)
-importFrom(RCurl, basicTextGatherer, curlPerform)
-importFrom(Rcpp, evalCpp)
+importFrom("methods", "new", "show", "as", "is")
+importFrom("utils", "str", "packageDescription")
+importFrom("stats", "update")
+importFrom("tools", "file_path_as_absolute")
+importFrom("RCurl", "basicTextGatherer", "curlPerform")
+importFrom("Rcpp", "evalCpp")
 
 exportClasses(
 

--- a/R/00classes.R
+++ b/R/00classes.R
@@ -4,7 +4,7 @@
 IMPLEMENTATIONS <- new.env( parent = emptyenv() )
 
 # invisible version of .Call
-.icall <- function(...) invisible(.Call(...))
+#.icall <- function(...) invisible(.Call(...))
 
 # {{{ class definitions
 # we need to formalize connection so that the S4 methods
@@ -172,9 +172,9 @@ setMethod("$", "Message", function(x, name) {
 
 	switch( name,
 		"has" = function( ... ) has(x, ...),
-		"clone" = function( ... )    .Call( "Message__clone"         , x@pointer, ..., PACKAGE = "RProtoBuf"),
-		"isInitialized" = function() .Call( "Message__is_initialized", x@pointer,      PACKAGE = "RProtoBuf"),
-		"descriptor" = function()    .Call( "Message__descriptor"     , x@pointer,      PACKAGE = "RProtoBuf" ),
+		"clone" = function( ... )    .Call( "Message__clone"         , x@pointer, PACKAGE = "RProtoBuf"),
+		"isInitialized" = function() .Call( "Message__is_initialized", x@pointer, PACKAGE = "RProtoBuf"),
+		"descriptor" = function()    .Call( "Message__descriptor"    , x@pointer, PACKAGE = "RProtoBuf"),
 
 		"size"  = function(field, ...) size(x, field, ... ),
 		"bytesize" = function() bytesize(x),
@@ -227,7 +227,7 @@ setMethod("$", "Descriptor", function(x, name) {
 
 
 		# default
-		.Call( "do_dollar_Descriptor", x@pointer, name )
+		.Call( "do_dollar_Descriptor", x@pointer, name, PACKAGE="RProtoBuf")
 	)
 } )
 setMethod( "$", "EnumDescriptor", function(x, name ){
@@ -490,7 +490,7 @@ setMethod( "update", "Message", function( object, ... ){
 	if( !length( named ) ){
 		return( object )
 	}
-	.Call( "update_message", object@pointer, named )
+	.Call( "update_message", object@pointer, named, PACKAGE="RProtoBuf")
 	object
 
 } )

--- a/R/clone.R
+++ b/R/clone.R
@@ -3,7 +3,7 @@ setGeneric( "clone", function( object, ... ){
 	standardGeneric( "clone" )
 } )
 ._clone.message <- function( object, ... ){
-	message <- .Call( "Message__clone", object@pointer )
+	message <- .Call( "Message__clone", object@pointer, PACKAGE="RProtoBuf")
 	update( message, ... )
 	message
 }

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -51,6 +51,5 @@ setMethod( "getExtension", "Message", function( object, field){
 			   containing_type(field)@type, "!=",
 			   object@type, ")"))
 	}
-        .Call( "getExtension", object@pointer, field,
-              PACKAGE = "RProtoBuf" )
+        .Call( "getExtension_cpp", object@pointer, field, PACKAGE = "RProtoBuf" )
 } )

--- a/R/has.R
+++ b/R/has.R
@@ -10,7 +10,7 @@ setGeneric( "has", function( object, name, ... ){
 	}
 }
 ._has_enum_name <- function( object, name, ...){
-  return(.Call( "has_enum_name", object@pointer, name, package = "RProtoBuf"))
+  return(.Call( "has_enum_name", object@pointer, name, PACKAGE = "RProtoBuf"))
 }
 
 setMethod( "has", "Message", ._has_message )

--- a/R/internals.R
+++ b/R/internals.R
@@ -44,7 +44,7 @@ readProtoFiles <- function(files,
 		files <- sapply(files[ex], function(x) file_path_as_absolute(x) )
 	}
 	directories <- unique( c( getwd(), dirname(files) ) )
-	.Call( "readProtoFiles", files, directories, PACKAGE = "RProtoBuf" )
+	.Call( "readProtoFiles_cpp", files, directories, PACKAGE = "RProtoBuf" )
 	invisible(NULL)
 }
 

--- a/R/merge.R
+++ b/R/merge.R
@@ -6,7 +6,7 @@ setMethod( "merge",
                         stop(sprintf("incompatible message types, cannot merge '%s' and '%s'", x@type, y@type))
 		}
 		
-		message <- .Call( "Message__merge", x@pointer, y@pointer )
+		message <- .Call( "Message__merge", x@pointer, y@pointer, PACKAGE="RProtoBuf")
 		message
 } )
 

--- a/R/unit_tests.R
+++ b/R/unit_tests.R
@@ -1,6 +1,5 @@
 
 run_unit_tests <- function(){
-	script <- system.file( "unitTests", "runTests.R", 
-		package = "RProtoBuf" ) 
+	script <- system.file( "unitTests", "runTests.R", package = "RProtoBuf" ) 
 	source( script )
 }

--- a/R/with.R
+++ b/R/with.R
@@ -10,10 +10,10 @@ generateActiveBindings <- function(data){
   		  makeActiveBinding( x, function(v){
   		    if( missing(v) ){
   		    	# get
-  		      .Call( "getMessageField", xp, x )
+  		      .Call( "getMessageField", xp, x, PACKAGE="RProtoBuf" )
   		    } else {
   		    	# set
-  		      .Call( "setMessageField", xp, x, v )
+  		      .Call( "setMessageField", xp, x, v, PACKAGE="RProtoBuf")
   		    }
   		  }, env )
   		} )

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,8 +3,15 @@
 \newcommand{\ghpr}{\href{https://github.com/eddelbuettel/rprotobuf/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/eddelbuettel/rprotobuf/issues/#1}{##1}}
 
-\section{Changes in RProtoBuf version 0.4.8 (2017-xx-yy)}{
+\section{Changes in RProtoBuf version 0.4.9 (2017-03-xx)}{
   \itemize{
+    \item A new file \code{init.c} was added with calls to
+    \code{R_registerRoutines()} and \code{R_useDynamicSymbols()}
+    \item Symbol registration is enable in \code{useDynLib}
+    \item Several missing \code{PACKAGE=} arguments were added to
+    \code{.Call}
+    \item Two (internal) C++ functions were renamed with suffix
+    \code{_cpp} to disambiguate them from R functions with the same name
     \item The `configure.ac` file was updated, and renamed from the
     older converntion `configure.in`, along with `src/Makevars`. (PR
     \ghpr{24} fixing \ghit{23}) 

--- a/src/extensions.cpp
+++ b/src/extensions.cpp
@@ -24,7 +24,7 @@
 
 namespace rprotobuf {
 
-RcppExport SEXP getExtension(SEXP pointer, SEXP sfielddesc) {
+RcppExport SEXP getExtension_cpp(SEXP pointer, SEXP sfielddesc) {
     /* grab the Message pointer */
     Rcpp::XPtr<GPB::Message> message(pointer);
     const GPB::Reflection* ref = message->GetReflection();

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,343 @@
+#include <R.h>
+#include <Rinternals.h>
+#include <stdlib.h> // for NULL
+#include <R_ext/Rdynload.h>
+
+/*
+  The following name(s) appear with different usages
+  e.g., with different numbers of arguments:
+
+    Message__clone
+
+  This needs to be resolved in the tables and any declarations.
+
+  DE 2017-03-05: Resolved, second entry with two arguments was in error
+*/
+
+/*
+  DE 2017-03-05:
+   - Below several entries were commented out as unresolvable
+   - A few were renamed with suffix _cpp to avoid name clash with R symbols of
+     the same name as we also enable .registration=TRUE in useDynLib in NAMESPACE
+*/
+
+/* FIXME:
+   Check these declarations against the C/Fortran source code.
+*/
+
+/* .Call calls */
+extern SEXP all_equal_messages(SEXP, SEXP, SEXP);
+extern SEXP ArrayInputStream__new(SEXP, SEXP);
+extern SEXP ArrayOutputStream__new(SEXP, SEXP);
+extern SEXP ConnectionInputStream_new(SEXP, SEXP);
+extern SEXP ConnectionOutputStream_new(SEXP, SEXP);
+extern SEXP Descriptor__as_character(SEXP);
+extern SEXP Descriptor__as_list(SEXP);
+extern SEXP Descriptor__as_Message(SEXP);
+extern SEXP Descriptor__containing_type(SEXP);
+extern SEXP Descriptor__enum_type(SEXP, SEXP);
+extern SEXP Descriptor__enum_type_count(SEXP);
+extern SEXP Descriptor__field(SEXP, SEXP);
+extern SEXP Descriptor__field_count(SEXP);
+extern SEXP Descriptor__fileDescriptor(SEXP);
+/*extern SEXP Descriptor__FindEnumTypeByName(SEXP, SEXP);*/
+extern SEXP Descriptor__FindFieldByName(SEXP, SEXP);
+extern SEXP Descriptor__FindFieldByNumber(SEXP, SEXP);
+extern SEXP Descriptor__FindNestedTypeByName(SEXP, SEXP);
+extern SEXP Descriptor__getMemberNames(SEXP);
+extern SEXP Descriptor__name(SEXP, SEXP);
+extern SEXP Descriptor__nested_type(SEXP, SEXP);
+extern SEXP Descriptor__nested_type_count(SEXP);
+extern SEXP Descriptor__readASCIIFromConnection(SEXP, SEXP, SEXP);
+extern SEXP Descriptor__readASCIIFromString(SEXP, SEXP, SEXP);
+extern SEXP Descriptor__readMessageFromConnection(SEXP, SEXP);
+extern SEXP Descriptor__readMessageFromFile(SEXP, SEXP);
+extern SEXP Descriptor__readMessageFromRawVector(SEXP, SEXP);
+extern SEXP Descriptor_getField(SEXP, SEXP, SEXP);
+extern SEXP do_dollar_Descriptor(SEXP, SEXP);
+extern SEXP EnumDescriptor__as_character(SEXP);
+extern SEXP EnumDescriptor__as_list(SEXP);
+extern SEXP EnumDescriptor__as_Message(SEXP);
+extern SEXP EnumDescriptor__containing_type(SEXP);
+extern SEXP EnumDescriptor__fileDescriptor(SEXP);
+extern SEXP EnumDescriptor__getConstantNames(SEXP);
+extern SEXP EnumDescriptor__getValueByIndex(SEXP, SEXP);
+extern SEXP EnumDescriptor__getValueByName(SEXP, SEXP);
+extern SEXP EnumDescriptor__getValueByNumber(SEXP, SEXP);
+extern SEXP EnumDescriptor__length(SEXP);
+extern SEXP EnumDescriptor__name(SEXP, SEXP);
+extern SEXP EnumDescriptor__value_count(SEXP);
+extern SEXP EnumValueDescriptor__as_character(SEXP);
+extern SEXP EnumValueDescriptor__as_Message(SEXP);
+extern SEXP EnumValueDescriptor__enum_type(SEXP);
+extern SEXP EnumValueDescriptor__number(SEXP);
+extern SEXP FieldDescriptor__as_character(SEXP);
+extern SEXP FieldDescriptor__as_Message(SEXP);
+extern SEXP FieldDescriptor__containing_type(SEXP);
+extern SEXP FieldDescriptor__cpp_type(SEXP);
+extern SEXP FieldDescriptor__default_value(SEXP);
+extern SEXP FieldDescriptor__enum_type(SEXP);
+extern SEXP FieldDescriptor__fileDescriptor(SEXP);
+extern SEXP FieldDescriptor__has_default_value(SEXP);
+extern SEXP FieldDescriptor__is_extension(SEXP);
+extern SEXP FieldDescriptor__is_optional(SEXP);
+extern SEXP FieldDescriptor__is_repeated(SEXP);
+extern SEXP FieldDescriptor__is_required(SEXP);
+extern SEXP FieldDescriptor__label(SEXP);
+extern SEXP FieldDescriptor__message_type(SEXP);
+extern SEXP FieldDescriptor__name(SEXP, SEXP);
+extern SEXP FieldDescriptor__number(SEXP);
+extern SEXP FieldDescriptor__type(SEXP);
+extern SEXP FileDescriptor__as_character(SEXP);
+extern SEXP FileDescriptor__as_list(SEXP);
+extern SEXP FileDescriptor__as_Message(SEXP);
+extern SEXP FileDescriptor__getMemberNames(SEXP);
+extern SEXP FileDescriptor__name(SEXP);
+extern SEXP FileInputStream_Close(SEXP);
+extern SEXP FileInputStream_GetErrno(SEXP);
+extern SEXP FileInputStream_new(SEXP, SEXP, SEXP);
+extern SEXP FileInputStream_SetCloseOnDelete(SEXP, SEXP);
+extern SEXP FileOutputStream_Close(SEXP);
+extern SEXP FileOutputStream_Flush(SEXP);
+extern SEXP FileOutputStream_GetErrno(SEXP);
+extern SEXP FileOutputStream_new(SEXP, SEXP, SEXP);
+extern SEXP FileOutputStream_SetCloseOnDelete(SEXP, SEXP);
+/*extern SEXP get_method_input_type(SEXP);*/
+extern SEXP get_method_output_prototype(SEXP);
+extern SEXP get_protobuf_library_version();
+extern SEXP get_value_of_enum(SEXP, SEXP);
+extern SEXP getEnumDescriptor(SEXP);
+extern SEXP getExtension_cpp(SEXP, SEXP);
+extern SEXP getExtensionDescriptor(SEXP);
+extern SEXP getMessageField(SEXP, SEXP);
+extern SEXP getProtobufDescriptor(SEXP);
+extern SEXP has_enum_name(SEXP, SEXP);
+extern SEXP identical_messages(SEXP, SEXP);
+extern SEXP Message__add_values(SEXP, SEXP, SEXP);
+extern SEXP Message__as_character(SEXP);
+extern SEXP Message__as_list(SEXP);
+extern SEXP Message__bytesize(SEXP);
+extern SEXP Message__clear(SEXP);
+extern SEXP Message__clear_field(SEXP, SEXP);
+extern SEXP Message__clone(SEXP);
+/*extern SEXP Message__clone(SEXP, SEXP);*/
+extern SEXP Message__descriptor(SEXP);
+extern SEXP Message__field_exists(SEXP, SEXP);
+extern SEXP Message__field_size(SEXP, SEXP);
+extern SEXP Message__fieldNames(SEXP);
+extern SEXP Message__fileDescriptor(SEXP);
+extern SEXP Message__get_field_values(SEXP, SEXP, SEXP);
+extern SEXP Message__get_payload(SEXP);
+extern SEXP Message__has_field(SEXP, SEXP);
+extern SEXP Message__is_initialized(SEXP);
+extern SEXP Message__length(SEXP);
+extern SEXP Message__merge(SEXP, SEXP);
+extern SEXP Message__num_extensions(SEXP);
+extern SEXP Message__serialize_to_file(SEXP, SEXP);
+extern SEXP Message__set_field_size(SEXP, SEXP, SEXP);
+extern SEXP Message__set_field_values(SEXP, SEXP, SEXP, SEXP);
+extern SEXP Message__swap(SEXP, SEXP, SEXP, SEXP);
+extern SEXP MethodDescriptor__as_character(SEXP);
+extern SEXP MethodDescriptor__as_Message(SEXP);
+extern SEXP MethodDescriptor__fileDescriptor(SEXP);
+extern SEXP MethodDescriptor__input_type(SEXP);
+extern SEXP MethodDescriptor__name(SEXP, SEXP);
+extern SEXP MethodDescriptor__output_type(SEXP);
+extern SEXP newProtocolBufferLookup(SEXP);
+extern SEXP newProtoMessage(SEXP);
+extern SEXP readProtoFiles_cpp(SEXP, SEXP);
+extern SEXP ServiceDescriptor__as_character(SEXP);
+extern SEXP ServiceDescriptor__as_list(SEXP);
+extern SEXP ServiceDescriptor__as_Message(SEXP);
+extern SEXP ServiceDescriptor__fileDescriptor(SEXP);
+extern SEXP ServiceDescriptor__getMethodNames(SEXP);
+/*extern SEXP ServiceDescriptor__method(SEXP, SEXP);*/
+extern SEXP ServiceDescriptor__name(SEXP, SEXP);
+/*extern SEXP ServiceDescriptor_getMethodByIndex(SEXP, SEXP);*/
+/*extern SEXP ServiceDescriptor_getMethodByName(SEXP, SEXP);*/
+/*extern SEXP ServiceDescriptor_method_count(SEXP);*/
+extern SEXP setMessageField(SEXP, SEXP, SEXP);
+extern SEXP update_message(SEXP, SEXP);
+extern SEXP valid_input_message(SEXP, SEXP);
+extern SEXP valid_output_message(SEXP, SEXP);
+extern SEXP ZeroCopyInputStream_BackUp(SEXP, SEXP);
+extern SEXP ZeroCopyInputStream_ByteCount(SEXP);
+extern SEXP ZeroCopyInputStream_Next(SEXP);
+extern SEXP ZeroCopyInputStream_ReadLittleEndian32(SEXP);
+extern SEXP ZeroCopyInputStream_ReadLittleEndian64(SEXP);
+extern SEXP ZeroCopyInputStream_ReadRaw(SEXP, SEXP);
+extern SEXP ZeroCopyInputStream_ReadString(SEXP, SEXP);
+extern SEXP ZeroCopyInputStream_ReadVarint32(SEXP);
+extern SEXP ZeroCopyInputStream_ReadVarint64(SEXP);
+extern SEXP ZeroCopyInputStream_Skip(SEXP, SEXP);
+extern SEXP ZeroCopyOutputStream_BackUp(SEXP, SEXP);
+extern SEXP ZeroCopyOutputStream_ByteCount(SEXP);
+extern SEXP ZeroCopyOutputStream_Next(SEXP, SEXP);
+extern SEXP ZeroCopyOutputStream_WriteLittleEndian32(SEXP, SEXP);
+extern SEXP ZeroCopyOutputStream_WriteLittleEndian64(SEXP, SEXP);
+extern SEXP ZeroCopyOutputStream_WriteRaw(SEXP, SEXP);
+extern SEXP ZeroCopyOutputStream_WriteString(SEXP, SEXP);
+extern SEXP ZeroCopyOutputStream_WriteVarint32(SEXP, SEXP);
+extern SEXP ZeroCopyOutputStream_WriteVarint64(SEXP, SEXP);
+
+static const R_CallMethodDef CallEntries[] = {
+    {"all_equal_messages",                       (DL_FUNC) &all_equal_messages,                        3},
+    {"ArrayInputStream__new",                    (DL_FUNC) &ArrayInputStream__new,                     2},
+    {"ArrayOutputStream__new",                   (DL_FUNC) &ArrayOutputStream__new,                    2},
+    {"ConnectionInputStream_new",                (DL_FUNC) &ConnectionInputStream_new,                 2},
+    {"ConnectionOutputStream_new",               (DL_FUNC) &ConnectionOutputStream_new,                2},
+    {"Descriptor__as_character",                 (DL_FUNC) &Descriptor__as_character,                  1},
+    {"Descriptor__as_list",                      (DL_FUNC) &Descriptor__as_list,                       1},
+    {"Descriptor__as_Message",                   (DL_FUNC) &Descriptor__as_Message,                    1},
+    {"Descriptor__containing_type",              (DL_FUNC) &Descriptor__containing_type,               1},
+    {"Descriptor__enum_type",                    (DL_FUNC) &Descriptor__enum_type,                     2},
+    {"Descriptor__enum_type_count",              (DL_FUNC) &Descriptor__enum_type_count,               1},
+    {"Descriptor__field",                        (DL_FUNC) &Descriptor__field,                         2},
+    {"Descriptor__field_count",                  (DL_FUNC) &Descriptor__field_count,                   1},
+    {"Descriptor__fileDescriptor",               (DL_FUNC) &Descriptor__fileDescriptor,                1},
+/*    {"Descriptor__FindEnumTypeByName",           (DL_FUNC) &Descriptor__FindEnumTypeByName,            2}, */
+    {"Descriptor__FindFieldByName",              (DL_FUNC) &Descriptor__FindFieldByName,               2},
+    {"Descriptor__FindFieldByNumber",            (DL_FUNC) &Descriptor__FindFieldByNumber,             2},
+    {"Descriptor__FindNestedTypeByName",         (DL_FUNC) &Descriptor__FindNestedTypeByName,          2},
+    {"Descriptor__getMemberNames",               (DL_FUNC) &Descriptor__getMemberNames,                1},
+    {"Descriptor__name",                         (DL_FUNC) &Descriptor__name,                          2},
+    {"Descriptor__nested_type",                  (DL_FUNC) &Descriptor__nested_type,                   2},
+    {"Descriptor__nested_type_count",            (DL_FUNC) &Descriptor__nested_type_count,             1},
+    {"Descriptor__readASCIIFromConnection",      (DL_FUNC) &Descriptor__readASCIIFromConnection,       3},
+    {"Descriptor__readASCIIFromString",          (DL_FUNC) &Descriptor__readASCIIFromString,           3},
+    {"Descriptor__readMessageFromConnection",    (DL_FUNC) &Descriptor__readMessageFromConnection,     2},
+    {"Descriptor__readMessageFromFile",          (DL_FUNC) &Descriptor__readMessageFromFile,           2},
+    {"Descriptor__readMessageFromRawVector",     (DL_FUNC) &Descriptor__readMessageFromRawVector,      2},
+    {"Descriptor_getField",                      (DL_FUNC) &Descriptor_getField,                       3},
+    {"do_dollar_Descriptor",                     (DL_FUNC) &do_dollar_Descriptor,                      2},
+    {"EnumDescriptor__as_character",             (DL_FUNC) &EnumDescriptor__as_character,              1},
+    {"EnumDescriptor__as_list",                  (DL_FUNC) &EnumDescriptor__as_list,                   1},
+    {"EnumDescriptor__as_Message",               (DL_FUNC) &EnumDescriptor__as_Message,                1},
+    {"EnumDescriptor__containing_type",          (DL_FUNC) &EnumDescriptor__containing_type,           1},
+    {"EnumDescriptor__fileDescriptor",           (DL_FUNC) &EnumDescriptor__fileDescriptor,            1},
+    {"EnumDescriptor__getConstantNames",         (DL_FUNC) &EnumDescriptor__getConstantNames,          1},
+    {"EnumDescriptor__getValueByIndex",          (DL_FUNC) &EnumDescriptor__getValueByIndex,           2},
+    {"EnumDescriptor__getValueByName",           (DL_FUNC) &EnumDescriptor__getValueByName,            2},
+    {"EnumDescriptor__getValueByNumber",         (DL_FUNC) &EnumDescriptor__getValueByNumber,          2},
+    {"EnumDescriptor__length",                   (DL_FUNC) &EnumDescriptor__length,                    1},
+    {"EnumDescriptor__name",                     (DL_FUNC) &EnumDescriptor__name,                      2},
+    {"EnumDescriptor__value_count",              (DL_FUNC) &EnumDescriptor__value_count,               1},
+    {"EnumValueDescriptor__as_character",        (DL_FUNC) &EnumValueDescriptor__as_character,         1},
+    {"EnumValueDescriptor__as_Message",          (DL_FUNC) &EnumValueDescriptor__as_Message,           1},
+    {"EnumValueDescriptor__enum_type",           (DL_FUNC) &EnumValueDescriptor__enum_type,            1},
+    {"EnumValueDescriptor__number",              (DL_FUNC) &EnumValueDescriptor__number,               1},
+    {"FieldDescriptor__as_character",            (DL_FUNC) &FieldDescriptor__as_character,             1},
+    {"FieldDescriptor__as_Message",              (DL_FUNC) &FieldDescriptor__as_Message,               1},
+    {"FieldDescriptor__containing_type",         (DL_FUNC) &FieldDescriptor__containing_type,          1},
+    {"FieldDescriptor__cpp_type",                (DL_FUNC) &FieldDescriptor__cpp_type,                 1},
+    {"FieldDescriptor__default_value",           (DL_FUNC) &FieldDescriptor__default_value,            1},
+    {"FieldDescriptor__enum_type",               (DL_FUNC) &FieldDescriptor__enum_type,                1},
+    {"FieldDescriptor__fileDescriptor",          (DL_FUNC) &FieldDescriptor__fileDescriptor,           1},
+    {"FieldDescriptor__has_default_value",       (DL_FUNC) &FieldDescriptor__has_default_value,        1},
+    {"FieldDescriptor__is_extension",            (DL_FUNC) &FieldDescriptor__is_extension,             1},
+    {"FieldDescriptor__is_optional",             (DL_FUNC) &FieldDescriptor__is_optional,              1},
+    {"FieldDescriptor__is_repeated",             (DL_FUNC) &FieldDescriptor__is_repeated,              1},
+    {"FieldDescriptor__is_required",             (DL_FUNC) &FieldDescriptor__is_required,              1},
+    {"FieldDescriptor__label",                   (DL_FUNC) &FieldDescriptor__label,                    1},
+    {"FieldDescriptor__message_type",            (DL_FUNC) &FieldDescriptor__message_type,             1},
+    {"FieldDescriptor__name",                    (DL_FUNC) &FieldDescriptor__name,                     2},
+    {"FieldDescriptor__number",                  (DL_FUNC) &FieldDescriptor__number,                   1},
+    {"FieldDescriptor__type",                    (DL_FUNC) &FieldDescriptor__type,                     1},
+    {"FileDescriptor__as_character",             (DL_FUNC) &FileDescriptor__as_character,              1},
+    {"FileDescriptor__as_list",                  (DL_FUNC) &FileDescriptor__as_list,                   1},
+    {"FileDescriptor__as_Message",               (DL_FUNC) &FileDescriptor__as_Message,                1},
+    {"FileDescriptor__getMemberNames",           (DL_FUNC) &FileDescriptor__getMemberNames,            1},
+    {"FileDescriptor__name",                     (DL_FUNC) &FileDescriptor__name,                      1},
+    {"FileInputStream_Close",                    (DL_FUNC) &FileInputStream_Close,                     1},
+    {"FileInputStream_GetErrno",                 (DL_FUNC) &FileInputStream_GetErrno,                  1},
+    {"FileInputStream_new",                      (DL_FUNC) &FileInputStream_new,                       3},
+    {"FileInputStream_SetCloseOnDelete",         (DL_FUNC) &FileInputStream_SetCloseOnDelete,          2},
+    {"FileOutputStream_Close",                   (DL_FUNC) &FileOutputStream_Close,                    1},
+    {"FileOutputStream_Flush",                   (DL_FUNC) &FileOutputStream_Flush,                    1},
+    {"FileOutputStream_GetErrno",                (DL_FUNC) &FileOutputStream_GetErrno,                 1},
+    {"FileOutputStream_new",                     (DL_FUNC) &FileOutputStream_new,                      3},
+    {"FileOutputStream_SetCloseOnDelete",        (DL_FUNC) &FileOutputStream_SetCloseOnDelete,         2},
+/*    {"get_method_input_type",                    (DL_FUNC) &get_method_input_type,                     1},*/
+    {"get_method_output_prototype",              (DL_FUNC) &get_method_output_prototype,               1},
+    {"get_protobuf_library_version",             (DL_FUNC) &get_protobuf_library_version,              0},
+    {"get_value_of_enum",                        (DL_FUNC) &get_value_of_enum,                         2},
+    {"getEnumDescriptor",                        (DL_FUNC) &getEnumDescriptor,                         1},
+    {"getExtension_cpp",                         (DL_FUNC) &getExtension_cpp,                          2},
+    {"getExtensionDescriptor",                   (DL_FUNC) &getExtensionDescriptor,                    1},
+    {"getMessageField",                          (DL_FUNC) &getMessageField,                           2},
+    {"getProtobufDescriptor",                    (DL_FUNC) &getProtobufDescriptor,                     1},
+    {"has_enum_name",                            (DL_FUNC) &has_enum_name,                             2},
+    {"identical_messages",                       (DL_FUNC) &identical_messages,                        2},
+    {"Message__add_values",                      (DL_FUNC) &Message__add_values,                       3},
+    {"Message__as_character",                    (DL_FUNC) &Message__as_character,                     1},
+    {"Message__as_list",                         (DL_FUNC) &Message__as_list,                          1},
+    {"Message__bytesize",                        (DL_FUNC) &Message__bytesize,                         1},
+    {"Message__clear",                           (DL_FUNC) &Message__clear,                            1},
+    {"Message__clear_field",                     (DL_FUNC) &Message__clear_field,                      2},
+    {"Message__clone",                           (DL_FUNC) &Message__clone,                            1},
+/*    {"Message__clone",                           (DL_FUNC) &Message__clone,                            2},*/
+    {"Message__descriptor",                      (DL_FUNC) &Message__descriptor,                       1},
+    {"Message__field_exists",                    (DL_FUNC) &Message__field_exists,                     2},
+    {"Message__field_size",                      (DL_FUNC) &Message__field_size,                       2},
+    {"Message__fieldNames",                      (DL_FUNC) &Message__fieldNames,                       1},
+    {"Message__fileDescriptor",                  (DL_FUNC) &Message__fileDescriptor,                   1},
+    {"Message__get_field_values",                (DL_FUNC) &Message__get_field_values,                 3},
+    {"Message__get_payload",                     (DL_FUNC) &Message__get_payload,                      1},
+    {"Message__has_field",                       (DL_FUNC) &Message__has_field,                        2},
+    {"Message__is_initialized",                  (DL_FUNC) &Message__is_initialized,                   1},
+    {"Message__length",                          (DL_FUNC) &Message__length,                           1},
+    {"Message__merge",                           (DL_FUNC) &Message__merge,                            2},
+    {"Message__num_extensions",                  (DL_FUNC) &Message__num_extensions,                   1},
+    {"Message__serialize_to_file",               (DL_FUNC) &Message__serialize_to_file,                2},
+    {"Message__set_field_size",                  (DL_FUNC) &Message__set_field_size,                   3},
+    {"Message__set_field_values",                (DL_FUNC) &Message__set_field_values,                 4},
+    {"Message__swap",                            (DL_FUNC) &Message__swap,                             4},
+    {"MethodDescriptor__as_character",           (DL_FUNC) &MethodDescriptor__as_character,            1},
+    {"MethodDescriptor__as_Message",             (DL_FUNC) &MethodDescriptor__as_Message,              1},
+    {"MethodDescriptor__fileDescriptor",         (DL_FUNC) &MethodDescriptor__fileDescriptor,          1},
+    {"MethodDescriptor__input_type",             (DL_FUNC) &MethodDescriptor__input_type,              1},
+    {"MethodDescriptor__name",                   (DL_FUNC) &MethodDescriptor__name,                    2},
+    {"MethodDescriptor__output_type",            (DL_FUNC) &MethodDescriptor__output_type,             1},
+    {"newProtocolBufferLookup",                  (DL_FUNC) &newProtocolBufferLookup,                   1},
+    {"newProtoMessage",                          (DL_FUNC) &newProtoMessage,                           1},
+    {"readProtoFiles_cpp",                       (DL_FUNC) &readProtoFiles_cpp,                        2},
+    {"ServiceDescriptor__as_character",          (DL_FUNC) &ServiceDescriptor__as_character,           1},
+    {"ServiceDescriptor__as_list",               (DL_FUNC) &ServiceDescriptor__as_list,                1},
+    {"ServiceDescriptor__as_Message",            (DL_FUNC) &ServiceDescriptor__as_Message,             1},
+    {"ServiceDescriptor__fileDescriptor",        (DL_FUNC) &ServiceDescriptor__fileDescriptor,         1},
+    {"ServiceDescriptor__getMethodNames",        (DL_FUNC) &ServiceDescriptor__getMethodNames,         1},
+/*    {"ServiceDescriptor__method",                (DL_FUNC) &ServiceDescriptor__method,                 2},*/
+    {"ServiceDescriptor__name",                  (DL_FUNC) &ServiceDescriptor__name,                   2},
+/*    {"ServiceDescriptor_getMethodByIndex",       (DL_FUNC) &ServiceDescriptor_getMethodByIndex,        2},*/
+/*    {"ServiceDescriptor_getMethodByName",        (DL_FUNC) &ServiceDescriptor_getMethodByName,         2},*/
+/*    {"ServiceDescriptor_method_count",           (DL_FUNC) &ServiceDescriptor_method_count,            1},*/
+    {"setMessageField",                          (DL_FUNC) &setMessageField,                           3},
+    {"update_message",                           (DL_FUNC) &update_message,                            2},
+    {"valid_input_message",                      (DL_FUNC) &valid_input_message,                       2},
+    {"valid_output_message",                     (DL_FUNC) &valid_output_message,                      2},
+    {"ZeroCopyInputStream_BackUp",               (DL_FUNC) &ZeroCopyInputStream_BackUp,                2},
+    {"ZeroCopyInputStream_ByteCount",            (DL_FUNC) &ZeroCopyInputStream_ByteCount,             1},
+    {"ZeroCopyInputStream_Next",                 (DL_FUNC) &ZeroCopyInputStream_Next,                  1},
+    {"ZeroCopyInputStream_ReadLittleEndian32",   (DL_FUNC) &ZeroCopyInputStream_ReadLittleEndian32,    1},
+    {"ZeroCopyInputStream_ReadLittleEndian64",   (DL_FUNC) &ZeroCopyInputStream_ReadLittleEndian64,    1},
+    {"ZeroCopyInputStream_ReadRaw",              (DL_FUNC) &ZeroCopyInputStream_ReadRaw,               2},
+    {"ZeroCopyInputStream_ReadString",           (DL_FUNC) &ZeroCopyInputStream_ReadString,            2},
+    {"ZeroCopyInputStream_ReadVarint32",         (DL_FUNC) &ZeroCopyInputStream_ReadVarint32,          1},
+    {"ZeroCopyInputStream_ReadVarint64",         (DL_FUNC) &ZeroCopyInputStream_ReadVarint64,          1},
+    {"ZeroCopyInputStream_Skip",                 (DL_FUNC) &ZeroCopyInputStream_Skip,                  2},
+    {"ZeroCopyOutputStream_BackUp",              (DL_FUNC) &ZeroCopyOutputStream_BackUp,               2},
+    {"ZeroCopyOutputStream_ByteCount",           (DL_FUNC) &ZeroCopyOutputStream_ByteCount,            1},
+    {"ZeroCopyOutputStream_Next",                (DL_FUNC) &ZeroCopyOutputStream_Next,                 2},
+    {"ZeroCopyOutputStream_WriteLittleEndian32", (DL_FUNC) &ZeroCopyOutputStream_WriteLittleEndian32,  2},
+    {"ZeroCopyOutputStream_WriteLittleEndian64", (DL_FUNC) &ZeroCopyOutputStream_WriteLittleEndian64,  2},
+    {"ZeroCopyOutputStream_WriteRaw",            (DL_FUNC) &ZeroCopyOutputStream_WriteRaw,             2},
+    {"ZeroCopyOutputStream_WriteString",         (DL_FUNC) &ZeroCopyOutputStream_WriteString,          2},
+    {"ZeroCopyOutputStream_WriteVarint32",       (DL_FUNC) &ZeroCopyOutputStream_WriteVarint32,        2},
+    {"ZeroCopyOutputStream_WriteVarint64",       (DL_FUNC) &ZeroCopyOutputStream_WriteVarint64,        2},
+    {NULL, NULL, 0}
+};
+
+void R_init_RProtoBuf(DllInfo *dll) {
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/src/rprotobuf.cpp
+++ b/src/rprotobuf.cpp
@@ -43,7 +43,7 @@ GPB::Message* CLONE(const GPB::Message* origin) {
  *
  * @param file proto file name
  */
-RcppExport SEXP readProtoFiles(SEXP file, SEXP dirs) {
+RcppExport SEXP readProtoFiles_cpp(SEXP file, SEXP dirs) {
     BEGIN_RCPP
     DescriptorPoolLookup::importProtoFiles(file, dirs);
     return R_NilValue;

--- a/src/rprotobuf.h
+++ b/src/rprotobuf.h
@@ -134,7 +134,7 @@ RcppExport SEXP do_dollar_Descriptor(SEXP, SEXP);
 RcppExport SEXP newProtoMessage(SEXP);
 RcppExport SEXP getProtobufDescriptor(SEXP);
 RcppExport SEXP getExtensionDescriptor(SEXP);
-RcppExport SEXP readProtoFiles(SEXP, SEXP);
+RcppExport SEXP readProtoFiles_cpp(SEXP, SEXP);
 RcppExport Rboolean isMessage(SEXP, const char*);
 RcppExport GPB::FieldDescriptor* getFieldDescriptor(const GPB::Message*, SEXP);
 


### PR DESCRIPTION
@murraystokely @jeroenooms If you have a moment for a quick code review I'd appreciate it

Background:  Mass email by Kurt requesting changes where `.Call` had `package=...` argument.   We had that in one spot, we also had a few where `PACKAGE=` was missing fixed.

I added registration support which r-devel now suggests and soon requires.  That uncovered a few issues:
- minor bug fix for `Message__clone` which was once called with extra `...` that is not needed
- had two renames to C++ functions by adding _cpp suffix as we had R functions with the same name
- commented out one unused `.Call()` helper function
- the generated `src/init.c` uncovered a entry points that are registered (ie have `.Call()`) but don't exist, so those registrations are commented