### PR TITLE
init base class in copy ctor, roll minor version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-08-14  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll minor version
+
+	* src/S4_classes.h: Initialize S4 base class in copy constructor
+	for S4_ArrayOutputStream class
+
 2017-08-13  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.4.10

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RProtoBuf
-Version: 0.4.10
-Date: 2017-08-13
+Version: 0.4.10.1
+Date: 2017-08-14
 Author: Romain Francois, Dirk Eddelbuettel, Murray Stokely and Jeroen Ooms
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Title: R Interface to the 'Protocol Buffers' 'API' (Version 2 or 3)

--- a/configure
+++ b/configure
@@ -5142,7 +5142,7 @@ fi
 
 echo "
 RProtoBuf $PACKAGE_VERSION
-===============
+================
 
 cflags:  ${PKG_CPPFLAGS}
 libs:    ${PKG_LIBS}

--- a/configure.ac
+++ b/configure.ac
@@ -128,7 +128,7 @@ AC_OUTPUT
 
 echo "
 RProtoBuf $PACKAGE_VERSION
-===============
+================
 
 cflags:  ${PKG_CPPFLAGS} 
 libs:    ${PKG_LIBS}

--- a/src/S4_classes.h
+++ b/src/S4_classes.h
@@ -1,6 +1,6 @@
 // S4_classes.h: R/C++ interface class library
 //
-// Copyright (C) 2010 - 2014  Dirk Eddelbuettel and Romain Francois
+// Copyright (C) 2010 - 2017  Dirk Eddelbuettel and Romain Francois
 //
 // This file is part of RProtoBuf.
 //
@@ -198,7 +198,9 @@ class S4_ArrayOutputStream : public Rcpp::S4 {
         slot("pointer") = wrapper;
     }
 
-    S4_ArrayOutputStream(const S4_ArrayOutputStream& other) { SetSexp(other.AsSexp()); }
+    S4_ArrayOutputStream(const S4_ArrayOutputStream& other) : S4(other) {
+        SetSexp(other.AsSexp());
+    }
     S4_ArrayOutputStream& operator=(const S4_ArrayOutputStream& other) {
         SetSexp(other.AsSexp());
         return *this;


### PR DESCRIPTION
gets rid of a (repeated) warning under `-Wextra`