### PR TITLE
Explicit proto import search path

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -78,7 +78,7 @@ exportMethods( "new", "[[", "[[<-", "$", "$<-", "show",
 
 	)
 
-export( "P", "readProtoFiles", "asMessage" )
+export( "P", "readProtoFiles", "readProtoFiles2", "asMessage" )
 
 if( exists( ".DollarNames", asNamespace("utils") ) ) importFrom( utils, .DollarNames )
 S3method(.DollarNames, Message )

--- a/R/internals.R
+++ b/R/internals.R
@@ -49,8 +49,9 @@ readProtoFiles <- function(files,
 }
 
 readProtoFiles2 <- function(files,
-                            dir = getwd(),
+                            dir = ".",
                             pattern = "\\.proto$",
+                            recursive = FALSE,
                             protoPath = getwd()
 	){
 
@@ -85,8 +86,10 @@ readProtoFiles2 <- function(files,
 		baseDirs <- file_search( dir )
 		for( i in seq_along( dir ) ) {
 			absPaths <-
-				list.files( file.path( baseDirs[i], dir[i] ), pattern = pattern, full.names = TRUE )
+				list.files( file.path( baseDirs[i], dir[i] ), pattern = pattern,
+                    recursive = recursive, full.names = TRUE )
 			files <- c( files, substr( absPaths, nchar( baseDirs[i] ) + 2, 10000L ) )
+			files <- sub( "^\\./", "", files )
 		}
 	}
 	missing_files <- files[ is.na( file_search( files ) ) ]

--- a/man/readProtoFiles.Rd
+++ b/man/readProtoFiles.Rd
@@ -11,7 +11,7 @@ message type names.
 }
 \usage{
 readProtoFiles(files, dir, package="RProtoBuf", pattern="\\\\.proto$", lib.loc=NULL)
-readProtoFiles2(files, dir=getwd(), pattern="\\\\.proto$", protoPath=getwd())
+readProtoFiles2(files, dir=getwd(), pattern="\\\\.proto$", recursive=FALSE, protoPath=getwd())
 }
 \arguments{
   \item{files}{Proto files}
@@ -21,7 +21,8 @@ readProtoFiles2(files, dir=getwd(), pattern="\\\\.proto$", protoPath=getwd())
   \item{package}{R package name. If \code{files} and \code{dir} are
   missing, "proto" files in the "proto" directory of the 
   package tree are imported.}
-  \item{pattern}{A filename pattern to match proto files.}
+  \item{pattern}{A filename pattern to match proto files when using \code{dir}.}
+  \item{recursive}{Whether to descend recursively into \code{dir}.}
   \item{lib.loc}{Library location.}
   \item{protoPath}{Search path for proto file imports.}
 }

--- a/man/readProtoFiles.Rd
+++ b/man/readProtoFiles.Rd
@@ -1,5 +1,6 @@
 \name{readProtoFiles}
 \alias{readProtoFiles}
+\alias{readProtoFiles2}
 \title{
 protocol buffer descriptor importer
 }
@@ -10,6 +11,7 @@ message type names.
 }
 \usage{
 readProtoFiles(files, dir, package="RProtoBuf", pattern="\\\\.proto$", lib.loc=NULL)
+readProtoFiles2(files, dir=getwd(), pattern="\\\\.proto$", protoPath=getwd())
 }
 \arguments{
   \item{files}{Proto files}
@@ -21,6 +23,16 @@ readProtoFiles(files, dir, package="RProtoBuf", pattern="\\\\.proto$", lib.loc=N
   package tree are imported.}
   \item{pattern}{A filename pattern to match proto files.}
   \item{lib.loc}{Library location.}
+  \item{protoPath}{Search path for proto file imports.}
+}
+\details{
+\code{readProtoFiles2} is different from \code{readProtoFiles} to be
+consistent with the behavior of \code{protoc} command line tool in
+being explicit about the search path for proto import statements. In addition,
+we also require that both \code{files} and \code{dir} arguments are
+interpreted relative to \code{protoPath}, so that there is consistency in
+future imports of the same files through import statements of other proto
+files.
 }
 \value{
 \code{NULL}, invisibly. 


### PR DESCRIPTION
This tries to address #39.

The new function is more consistent with the behavior of `protoc` command line tool, and is easy enough for end users to get right. It expects that all provided paths are relative to an explicit search path.

With the previous function, the working dir was always added to the search path, and the `files` argument was always taken as an absolute path. I tried to change the existing function but it was difficult to be backward compatible in a clean way, hence the new function.

Open to suggestions on naming the new function.