### PR TITLE
[windows-build] upgrade protobuf library to 3.2.0 provided by [rwinli…  …b/protobuf](https://github.com/rwinlib/protobuf/releases/tag/v3.2.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: RProtoBuf
-Version: 0.4.11.1
+Version: 0.4.11.2
 Date: 2017-11-20
 Author: Romain Francois, Dirk Eddelbuettel, Murray Stokely and Jeroen Ooms
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
@@ -20,5 +20,5 @@ SystemRequirements: ProtoBuf libraries and compiler version 2.2.0 or later;
  installed as libprotoc-dev, libprotobuf-dev and protobuf-compiler, while on
  Fedora/CentOS protobuf-devel and protobuf-compiler are needed.
 BugReports: https://github.com/eddelbuettel/rprotobuf/issues
-URL: https://github.com/eddelbuettel/rprotobuf 
+URL: https://github.com/eddelbuettel/rprotobuf
 License: GPL (>= 2)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,7 @@
 # Links against libprotobuf build from Rtools gcc toolchain.
 COMPILED_BY ?= gcc-4.6.3
-PKG_CPPFLAGS= -I../windows/protobuf-3.0.0/include
-PKG_LIBS= -L../windows/protobuf-3.0.0/lib${subst gcc,,${COMPILED_BY}}${R_ARCH} -lprotobuf
+PKG_CPPFLAGS= -I../windows/protobuf-3.2.0/include
+PKG_LIBS= -L../windows/protobuf-3.2.0/lib${subst gcc,,${COMPILED_BY}}${R_ARCH} -lprotobuf
 
 ## Make this C++11 so that we get better int64 support and more
 CXX_STD=CXX11
@@ -9,7 +9,7 @@ CXX_STD=CXX11
 all: clean winlibs
 
 clean:
-	rm -f $(OBJECTS) $(SHLIB) 
+	rm -f $(OBJECTS) $(SHLIB)
 
 winlibs:
 	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,8 +1,8 @@
 # Build against protobuf libs compiled with Rtools
 # by Jeroen Ooms. Last updated: August 2016
-if (!file.exists("../windows/protobuf-3.0.0/include/google/protobuf/descriptor.h")) {
+if (!file.exists("../windows/protobuf-3.2.0/include/google/protobuf/descriptor.h")) {
     if (getRversion() < "3.3.0") setInternet2()
-    download.file("https://github.com/rwinlib/protobuf/archive/v3.0.0.zip", "lib.zip", quiet = TRUE)
+    download.file("https://github.com/rwinlib/protobuf/archive/v3.2.0.zip", "lib.zip", quiet = TRUE)
     dir.create("../windows", showWarnings = FALSE)
     unzip("lib.zip", exdir = "../windows")
     unlink("lib.zip")


### PR DESCRIPTION
Addresses: [RProtoBuf fails for large messages (64MB+)](https://github.com/eddelbuettel/rprotobuf/issues/41)