### PR TITLE
Unclass lists before serializing them 

### DIFF
--- a/R/rexp_obj.R
+++ b/R/rexp_obj.R
@@ -67,6 +67,8 @@ rexp_list <- function(obj){
   # some R objects return themselves when subindexed
   if (length(obj) > 0 && identical(obj, obj[[1]])) {
       xobj <- rexp_obj(unlist(obj))
+  } else if (is(obj, "POSIXlt")) {
+      xobj <- lapply(unclass(obj), rexp_obj)
   } else {
       xobj <- lapply(obj, rexp_obj)
   }

--- a/inst/unitTests/runit.serialize_pb.R
+++ b/inst/unitTests/runit.serialize_pb.R
@@ -48,3 +48,8 @@ test.serialize.sublist <- function() {
     x <- packageVersion("RProtoBuf")
     checkIdentical(x, unserialize_pb(serialize_pb(x, NULL)), msg="checking sublists")
 }
+
+test.serialize.posixlt <- function() {
+    x <- as.POSIXlt("1970-01-01T00:00:00Z")
+    checkIdentical(x, unserialize_pb(serialize_pb(x, NULL)), msg="checking posixlt")
+}


### PR DESCRIPTION
as some classes overwrite the default accessor.

Relates to https://github.com/eddelbuettel/rprotobuf/issues/47