### PR TITLE
enfore R 3.4 for now as run.sh has switched to R 3.5 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ sudo: required
 dist: trusty
 
 env:
+  global:
+    - R_VERSION="3.4"
   matrix: 
     # set up a test matrix for both ProtoBuf library versions: "v2" which we source
     # from Ubuntu "trusty" as usual, and "v3" which we source from Dirk's PPA where
@@ -16,7 +18,7 @@ env:
   
 before_install:
   - curl -OLs https://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
-  ## PPA for Rcpp and some other packages
+  ## PPA for Rcpp and some other packages; use 'ppa:edd/r-3.5' for R 3.5 (no ProtoBuf)
   - sudo add-apt-repository -y ppa:edd/misc
   - ./run.sh bootstrap
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2018-09-02  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .travis.yml: Enfor R version 3.4 for now as the PPA we need for the
+	Protocol Buffers library has r-cran-* packages built for R 3.4
+
 2018-07-25  Dirk Eddelbuettel  <edd@debian.org>
 
 	* configure.ac: Set CXX and CXXFLAGS values by calling R to reflect


### PR DESCRIPTION
we need to update the PPA with an updated Protocol Buffers library
or use an alternative mechanism (such as eg Docker)