### PR TITLE
Feature/travis docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,27 @@
-# Run Travis CI for R using https://eddelbuettel.github.io/r-travis/
+# Run Travis CI for R via Docker
+#
+# Made by Dirk Eddelbuettel in September 2018 and released under GPL (>=2)
 
-language: c
-
-sudo: required
-
+os: linux
 dist: trusty
+sudo: required
+services: docker
 
 env:
   global:
-    - R_VERSION="3.4"
-  matrix: 
-    # set up a test matrix for both ProtoBuf library versions: "v2" which we source
-    # from Ubuntu "trusty" as usual, and "v3" which we source from Dirk's PPA where
-    # an unofficial / local build of ProtoBuf 3.0.0 is available (sans Java)
-    - PROTOBUF="v2"
-    - PROTOBUF="v3"
-  
+    - DOCKER_OPTS="--rm -ti -v $(pwd):/mnt -w /mnt"
+      DOCKER_CNTR="rprotobuf/ci"
+      R_BLD_CHK_OPTS="--no-build-vignettes --no-manual"
+
 before_install:
-  - curl -OLs https://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
-  ## PPA for Rcpp and some other packages; use 'ppa:edd/r-3.5' for R 3.5 (no ProtoBuf)
-  - sudo add-apt-repository -y ppa:edd/misc
-  - ./run.sh bootstrap
+ - docker pull ${DOCKER_CNTR}
+ - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} r -p -e 'sessionInfo()'
 
 install:
-  - ./run.sh install_aptget libprotobuf-dev libprotoc-dev protobuf-compiler r-cran-rcpp r-cran-runit r-cran-rcurl r-cran-pinp
+ - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD build ${R_BLD_CHK_OPTS} .
 
 script:
-  - ./run.sh run_tests
+ - docker run ${DOCKER_OPTS} ${DOCKER_CNTR} R CMD check ${R_BLD_CHK_OPTS} RProtoBuf*.tar.gz
 
 after_failure:
   - ./run.sh dump_logs

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2018-09-08  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .travis.yml: Rewritten to use rprotobuf/ci Docker container
+
 2018-09-07  Dirk Eddelbuettel  <edd@debian.org>
 
 	* docker/run/Dockerfile: Added Dockerfile for deployment

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,9 @@
     C++ setup (CRAN request).
     \item \code{POSIXlt} elements are now properly serialized too
     (Jeffrey Shen in \ghpr{48} and \ghpr{50} fixing \ghit{47})
+    \item Added two Dockerfiles for continuous integration and use; see
+    \href{https://cloud.docker.com/swarm/rprotobuf/repository/list}{this
+      url} for more.
   }
 }
 


### PR DESCRIPTION
This switches Travis CI to using the custom (and current) Docker container, a scheme I have started to use in a few projects needing current external libraries.  Works well.