### PR TITLE
Add a S3 dispatch of all.equal() for Message objects and use it in S4 method

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -101,6 +101,8 @@ S3method( as.list, EnumDescriptor )
 S3method( as.list, FileDescriptor )
 S3method( as.list, ServiceDescriptor )
 
+S3method( all.equal, Message )
+
 # constants
 exportPattern( "^TYPE_" )
 exportPattern( "^CPPTYPE_" )

--- a/R/identical.R
+++ b/R/identical.R
@@ -14,6 +14,9 @@ setMethod( "!=", c( e1 = "Message", e2 = "Message" ), function(e1, e2 ){
 setGeneric( "all.equal" )
 setMethod( "all.equal", c( target = "Message", current = "Message" ), 
 	function(target, current, tolerance = .Machine$double.eps^0.5, ...){
-	.Call( "all_equal_messages", target@pointer, current@pointer, tolerance, PACKAGE = "RProtoBuf" )
+        all.equal.Message(target, current, tolerance, ...)
 } )
 
+all.equal.Message <- function(target, current, tolerance = .Machine$double.eps^0.5, ...){
+	.Call( "all_equal_messages", target@pointer, current@pointer, tolerance, PACKAGE = "RProtoBuf" )
+}


### PR DESCRIPTION
This is to fix #53.

[More details](https://stat.ethz.ch/R-manual/R-devel/library/methods/html/Methods_for_S3.html) on the need to create both S3 and S4 methods for the same generic.