### PR TITLE
Handle ServiceDescriptor::FindMethodByName() taking std::string_view

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2020-05-28  Adam Cozzette  <acozzette@google.com>
+
+	* src/wrapper_ServiceDescriptor.cpp: Support FindMethodByName() taking
+	std::string_view
+	* src/RcppMacros.h: Idem
+
 2020-03-26  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.4.17

--- a/src/RcppMacros.h
+++ b/src/RcppMacros.h
@@ -148,4 +148,15 @@ BEGIN_RCPP                                                            \
 END_RCPP                                                              \
 }
 
+/* We need a special case macro for methods taking a std::string_view, because
+ * Rcpp::internal::converter will not automatically convert to that type. */
+#define RPB_XP_METHOD_CAST_1_STRING(__NAME__,__CLASS__,__METHOD__,__CAST__)               \
+extern "C" SEXP __NAME__( SEXP xp ,  SEXP x0 ){                                           \
+BEGIN_RCPP                                                                                \
+        ::Rcpp::XPtr< __CLASS__ > ptr(xp) ;                                               \
+        return ::Rcpp::wrap( __CAST__( ptr->__METHOD__(                                   \
+            static_cast<const std::string&>( ::Rcpp::internal::converter( x0 ) ) ) ) ) ;  \
+END_RCPP                                                                                  \
+}
+
 #endif

--- a/src/wrapper_ServiceDescriptor.cpp
+++ b/src/wrapper_ServiceDescriptor.cpp
@@ -12,8 +12,8 @@ RPB_XP_METHOD_0(METHOD(method_count), GPB::ServiceDescriptor, method_count)
 RPB_XP_METHOD_0(METHOD(as_character), GPB::ServiceDescriptor, DebugString)
 
 RPB_XP_METHOD_CAST_1(METHOD(getMethodByIndex), GPB::ServiceDescriptor, method, S4_MethodDescriptor)
-RPB_XP_METHOD_CAST_1(METHOD(getMethodByName), GPB::ServiceDescriptor, FindMethodByName,
-                     S4_MethodDescriptor)
+RPB_XP_METHOD_CAST_1_STRING(METHOD(getMethodByName), GPB::ServiceDescriptor, FindMethodByName,
+                            S4_MethodDescriptor)
 
 RPB_FUNCTION_1(Rcpp::CharacterVector, METHOD(getMethodNames),
                Rcpp::XPtr<GPB::ServiceDescriptor> desc) {


### PR DESCRIPTION
The `ServiceDescriptor::FindMethodByName()` method will hopefully soon
accept `std::string_view` instead of `const std::string&`, so this commit
updates RProtoBuf to be compatible with that change. I created a new
macro `RPB_XP_METHOD_CAST_1_STRING` which explicitly converts to
std::string before calling `FindMethodByName()`.