### PR TITLE
Add extra parameters to toJSON method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,3 @@ GPATH
 GRTAGS
 GTAGS
 *~
-config.log
-config.status
-src/Makevars

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ GPATH
 GRTAGS
 GTAGS
 *~
+config.log
+config.status
+src/Makevars

--- a/R/00classes.R
+++ b/R/00classes.R
@@ -189,7 +189,11 @@ setMethod("$", "Message", function(x, name) {
 		"set" = function(...) set( x, ... ),
 		"fetch" = function(...) fetch(x, ... ),
 		"toString" = function(...) toString( x, ... ),
-		"toJSON" = function(...) toJSON( x, ... ),
+		"toJSON" = function(preserve_proto_field_names = FALSE, always_print_primitive_fields = FALSE, ...)
+		  toJSON(x,
+				 preserve_proto_field_names = preserve_proto_field_names,
+				 always_print_primitive_fields = always_print_primitive_fields,
+				 ... ),
 		"add" = function(...) add( x, ...),
 
 		"serialize" = function(...) serialize( x, ... ),

--- a/R/00classes.R
+++ b/R/00classes.R
@@ -189,11 +189,10 @@ setMethod("$", "Message", function(x, name) {
 		"set" = function(...) set( x, ... ),
 		"fetch" = function(...) fetch(x, ... ),
 		"toString" = function(...) toString( x, ... ),
-		"toJSON" = function(preserve_proto_field_names = FALSE, always_print_primitive_fields = FALSE, ...)
-		  toJSON(x,
-				 preserve_proto_field_names = preserve_proto_field_names,
-				 always_print_primitive_fields = always_print_primitive_fields,
-				 ... ),
+                "toJSON" = function(preserve_proto_field_names = FALSE, always_print_primitive_fields = FALSE, ...)
+            		toJSON(x,
+                               preserve_proto_field_names = preserve_proto_field_names,
+                               always_print_primitive_fields = always_print_primitive_fields, ... ),
 		"add" = function(...) add( x, ...),
 
 		"serialize" = function(...) serialize( x, ... ),

--- a/R/debug_string.R
+++ b/R/debug_string.R
@@ -44,11 +44,14 @@ setMethod( "toString", "MethodDescriptor", ._toString_MethodDescriptor )
 setMethod( "toString", "FileDescriptor", ._toString_FileDescriptor )
 setMethod( "toString", "EnumValueDescriptor", ._toString_EnumValueDescriptor )
 
-setGeneric( "toJSON", function( x ){
+setGeneric( "toJSON", function( x, ... ) {
     standardGeneric( "toJSON" )
 } )
-setMethod( "toJSON", c( x = "Message" ),
-function(x) {
-    .Call( "Message__as_json", x@pointer, PACKAGE = "RProtoBuf")
+setMethod( "toJSON", c( x = "Message"),
+function(x, preserve_proto_field_names = FALSE, always_print_primitive_fields = FALSE) {
+    .Call( "Message__as_json", x@pointer,
+          preserve_proto_field_names,
+          always_print_primitive_fields,
+          PACKAGE = "RProtoBuf")
 } )
 

--- a/man/Message-class.Rd
+++ b/man/Message-class.Rd
@@ -47,7 +47,11 @@ as an external pointer.
     This is built from a call to the \code{DebugString} method of the \code{Message} object}
     \item{toString}{\code{signature(x = "Message")}: same as \code{as.character} }
     \item{toJSON}{\code{signature(x = "Message")}: returns the JSON representation of the message.
-    This is built from a call to the \code{google::protobuf::util::MessageToJsonString} method}
+    This is built from a call to the
+    \code{google::protobuf::util::MessageToJsonString} method and
+    accepts two arguments \code{preserve_proto_field_names} - if FALSE (the default) convert field names to camelCase
+    \code{always_print_primitive_fields} - whether to return the default
+    value for missing primitive fields (default false)}
     \item{$<-}{\code{signature(x = "Message")}: set the value of a field of the message. }
     \item{$}{\code{signature(x = "Message")}: gets the value of a field. 
     Primitive types are brought back to R as R objects of the closest matching R type. 

--- a/src/init.c
+++ b/src/init.c
@@ -117,7 +117,7 @@ extern SEXP has_enum_name(SEXP, SEXP);
 extern SEXP identical_messages(SEXP, SEXP);
 extern SEXP Message__add_values(SEXP, SEXP, SEXP);
 extern SEXP Message__as_character(SEXP);
-extern SEXP Message__as_json(SEXP);
+extern SEXP Message__as_json(SEXP, SEXP, SEXP);
 extern SEXP Message__as_list(SEXP);
 extern SEXP Message__bytesize(SEXP);
 extern SEXP Message__clear(SEXP);
@@ -276,7 +276,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"identical_messages",                       (DL_FUNC) &identical_messages,                        2},
     {"Message__add_values",                      (DL_FUNC) &Message__add_values,                       3},
     {"Message__as_character",                    (DL_FUNC) &Message__as_character,                     1},
-    {"Message__as_json",                         (DL_FUNC) &Message__as_json,                          1},
+    {"Message__as_json",                         (DL_FUNC) &Message__as_json,                          3},
     {"Message__as_list",                         (DL_FUNC) &Message__as_list,                          1},
     {"Message__bytesize",                        (DL_FUNC) &Message__bytesize,                         1},
     {"Message__clear",                           (DL_FUNC) &Message__clear,                            1},

--- a/src/wrapper_Message.cpp
+++ b/src/wrapper_Message.cpp
@@ -439,13 +439,19 @@ RPB_FUNCTION_1(Rcpp::CharacterVector, METHOD(fieldNames), Rcpp::XPtr<GPB::Messag
  * Returns the JSON representation of the message.
  *
  * @param xp external pointer to a Message
+ * @param preserve_proto_field_names If FALSE (the default) convert field names to camelCase.
+ * @param always_print_primitive_fields Whether to return the default value for missing primitive fields. (default false)
  *
  * @return JSON representation of the message as a single element R character vector (STRSXP)
  */
-RPB_FUNCTION_1(Rcpp::CharacterVector, METHOD(as_json), Rcpp::XPtr<GPB::Message> message) {
+RPB_FUNCTION_3(Rcpp::CharacterVector, METHOD(as_json), Rcpp::XPtr<GPB::Message> message,
+               bool preserve_proto_field_names,
+               bool always_print_primitive_fields) {
 #ifdef PROTOBUF_JSON_UTIL
     GPB::util::JsonPrintOptions opts;
     opts.add_whitespace = true;
+    opts.preserve_proto_field_names = preserve_proto_field_names;
+    opts.always_print_primitive_fields = always_print_primitive_fields;
 
     std::string buf;
     GPB::util::Status status = GPB::util::MessageToJsonString(*message, &buf, opts);


### PR DESCRIPTION
Adding `preserve_proto_field_names = FALSE, always_print_primitive_fields = FALSE` parameters as per https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.util.json_util#JsonPrintOptions