### PR TITLE
Apply UCRT patch by Tomas, roll minor version

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2021-12-14  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version): Roll minor version and date
+
+	* src/Makevars.ucrt: Applied patch by Tomas Kalibera that is part of
+	his changes for the Windows utf8-enhabced ucrt3 builds of R 4.2.0
+
 2021-10-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Update JSS article url to doi form per JSS request,
@@ -13,7 +20,7 @@
 	* .github/workflows/docker.yaml: Add action to build and push
 	containers with cron set to monthly schedule
 
-2019-06-27  Jeroen Ooms  <jeroen@berkeley.edu>
+2021-06-27  Jeroen Ooms  <jeroen@berkeley.edu>
 
 	* src/Makevars.win: Support UCRT build
 	* src/Makevars.ucrt: Idem

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RProtoBuf
 Version: 0.4.17.3
-Date: 2021-06-11
+Date: 2021-12-14
 Author: Romain Francois, Dirk Eddelbuettel, Murray Stokely and Jeroen Ooms
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Title: R Interface to the 'Protocol Buffers' 'API' (Version 2 or 3)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -7,14 +7,16 @@
   \itemize{
     \item Support \code{string_view}  in \code{FindMethodByName()} (Adam
     Cozzette in \ghpr{72}).
-    \item CI use has been updated first at Travis and at GitHub (Dirk in
+    \item CI use was updated first at Travis, later at GitHub and
+    now uses \href{https://eddelbuettel.github.io/r-ci/}{r-ci} (Dirk in
     \ghpr{74} and (parts of) \ghpr{76}).
     \item The (to the best of our knowledge) unused minimal RPC
     mechanism has been removed, retiring one method and one class as
     well as the import of the \pkg{RCurl} package (Dirk in \ghpr{76}).
     \item The \code{toJSON()} method supports two (upstream) formatting
-    toggles (Vitali Spinu in \ghpr{79) with minor edit by Dirk).
-    \item Windows UCRT builds are now supported (Jeroen in \ghpr{81}).
+    toggles (Vitali Spinu in \ghpr{79} with minor edit by Dirk).
+    \item Windows UCRT builds are now supported (Jeroen in \ghpr{81},
+    Dirk and Tomas Kalibera).
   }
 }
 

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,2 +1,9 @@
-CRT=-ucrt
-include Makevars.win
+PKG_LIBS= -lprotobuf
+
+## Make this C++11 so that we get better int64 support and more
+CXX_STD=CXX11
+
+all: clean
+
+clean:
+	rm -f $(OBJECTS) $(SHLIB)


### PR DESCRIPTION
This PR brings a patch from CRAN for ucrt3 (which maintainers have now been requested by email), and a typo fix for NEWS.

It seems time for a new upstream as we also carry two other small fixes, and the RPC deprecation.  So suggest to merge and then call it a 0.4.18 release.