### PR TITLE
Expose TextFormat for Message->character conversion

### DIFF
--- a/R/00classes.R
+++ b/R/00classes.R
@@ -192,7 +192,8 @@ setMethod("$", "Message", function(x, name) {
                 "toJSON" = function(preserve_proto_field_names = FALSE, always_print_primitive_fields = FALSE, ...)
             		toJSON(x, preserve_proto_field_names = preserve_proto_field_names,
                            always_print_primitive_fields = always_print_primitive_fields, ... ),
-        "toTextFormat" = function() toTextFormat(x),
+		"toTextFormat" = function() toTextFormat(x),
+		"toDebugString" = function() toDebugString(x),
 		"add" = function(...) add( x, ...),
 
 		"serialize" = function(...) serialize( x, ... ),

--- a/R/00classes.R
+++ b/R/00classes.R
@@ -192,6 +192,7 @@ setMethod("$", "Message", function(x, name) {
                 "toJSON" = function(preserve_proto_field_names = FALSE, always_print_primitive_fields = FALSE, ...)
             		toJSON(x, preserve_proto_field_names = preserve_proto_field_names,
                            always_print_primitive_fields = always_print_primitive_fields, ... ),
+        "toTextFormat" = function() toTextFormat(x),
 		"add" = function(...) add( x, ...),
 
 		"serialize" = function(...) serialize( x, ... ),

--- a/R/debug_string.R
+++ b/R/debug_string.R
@@ -1,10 +1,10 @@
 
 ._toString_Message <- function(x, debug = getOption("RProtoBuf.toString.debug", TRUE), ...){
-    if (isTRUE(debug)) {
-        .Call( "Message__as_character", x@pointer, PACKAGE = "RProtoBuf" )
-    } else {
-        .Call( "Message__print_text_format", x@pointer, PACKAGE = "RProtoBuf")
-    }
+	if (isTRUE(debug)) {
+		.Call( "Message__as_character", x@pointer, PACKAGE = "RProtoBuf" )
+	} else {
+		.Call( "Message__print_text_format", x@pointer, PACKAGE = "RProtoBuf")
+	}
 }
 ._toString_Descriptor <- function(x, ...){
 	.Call( "Descriptor__as_character", x@pointer, PACKAGE = "RProtoBuf" )
@@ -60,9 +60,9 @@ function(x, preserve_proto_field_names = FALSE, always_print_primitive_fields = 
 } )
 
 setGeneric( "toDebugString", function( x ) {
-    standardGeneric( "toDebugString" )
+  standardGeneric( "toDebugString" )
 } )
 setMethod( "toDebugString", c( x = "Message"),
-          function(x) {
-              .Call( "Message__as_character", x@pointer, PACKAGE = "RProtoBuf")
-          } )
+  function(x) {
+    .Call( "Message__as_character", x@pointer, PACKAGE = "RProtoBuf")
+  } )

--- a/R/debug_string.R
+++ b/R/debug_string.R
@@ -55,3 +55,10 @@ function(x, preserve_proto_field_names = FALSE, always_print_primitive_fields = 
           PACKAGE = "RProtoBuf")
 } )
 
+setGeneric( "toDebugString", function( x ) {
+    standardGeneric( "toDebugString" )
+} )
+setMethod( "toDebugString", c( x = "Message"),
+          function(x) {
+              .Call( "Message__as_character", x@pointer, PACKAGE = "RProtoBuf")
+          } )

--- a/R/debug_string.R
+++ b/R/debug_string.R
@@ -1,6 +1,10 @@
 
-._toString_Message <- function(x, ...){
-	.Call( "Message__as_character", x@pointer, PACKAGE = "RProtoBuf" )
+._toString_Message <- function(x, debug = getOption("RProtoBuf.toString.debug", TRUE), ...){
+    if (isTRUE(debug)) {
+        .Call( "Message__as_character", x@pointer, PACKAGE = "RProtoBuf" )
+    } else {
+        .Call( "Message__print_text_format", x@pointer, PACKAGE = "RProtoBuf")
+    }
 }
 ._toString_Descriptor <- function(x, ...){
 	.Call( "Descriptor__as_character", x@pointer, PACKAGE = "RProtoBuf" )

--- a/R/text_format.R
+++ b/R/text_format.R
@@ -1,0 +1,7 @@
+setGeneric( "toTextFormat", function( x ) {
+    standardGeneric( "toTextFormat" )
+} )
+setMethod( "toTextFormat", c( x = "Message"),
+          function(x) {
+              .Call( "Message__print_text_format", x@pointer, PACKAGE = "RProtoBuf")
+          } )

--- a/R/text_format.R
+++ b/R/text_format.R
@@ -2,6 +2,6 @@ setGeneric( "toTextFormat", function( x ) {
     standardGeneric( "toTextFormat" )
 } )
 setMethod( "toTextFormat", c( x = "Message"),
-          function(x) {
-              .Call( "Message__print_text_format", x@pointer, PACKAGE = "RProtoBuf")
-          } )
+function(x) {
+    .Call( "Message__print_text_format", x@pointer, PACKAGE = "RProtoBuf" )
+} )

--- a/inst/tinytest/test_messages.R
+++ b/inst/tinytest/test_messages.R
@@ -48,4 +48,6 @@ expect_error(a$repeated_nested_message <- list(
 expect_error(a$repeated_nested_message <- list(
     new(protobuf_unittest.TestAllTypes.NestedMessage, bb=4),
     "foo"))
+
+expect_equal(a$toTextFormat(), "OptionalGroup {\n  a: 3\n}\nrepeated_nested_message {\n  bb: 3\n}\nrepeated_nested_message {\n  bb: 4\n}")
 #}

--- a/inst/tinytest/test_messages.R
+++ b/inst/tinytest/test_messages.R
@@ -50,4 +50,7 @@ expect_error(a$repeated_nested_message <- list(
     "foo"))
 
 expect_equal(a$toTextFormat(), "OptionalGroup {\n  a: 3\n}\nrepeated_nested_message {\n  bb: 3\n}\nrepeated_nested_message {\n  bb: 4\n}\n")
+expect_equal(a$toDebugString(), a$toString())
+expect_equal(a$toString(debug = FALSE), a$toTextFormat())
+expect_equal(a$toString(debug = TRUE), a$toDebugString())
 #}

--- a/inst/tinytest/test_messages.R
+++ b/inst/tinytest/test_messages.R
@@ -49,5 +49,5 @@ expect_error(a$repeated_nested_message <- list(
     new(protobuf_unittest.TestAllTypes.NestedMessage, bb=4),
     "foo"))
 
-expect_equal(a$toTextFormat(), "OptionalGroup {\n  a: 3\n}\nrepeated_nested_message {\n  bb: 3\n}\nrepeated_nested_message {\n  bb: 4\n}")
+expect_equal(a$toTextFormat(), "OptionalGroup {\n  a: 3\n}\nrepeated_nested_message {\n  bb: 3\n}\nrepeated_nested_message {\n  bb: 4\n}\n")
 #}

--- a/man/Message-class.Rd
+++ b/man/Message-class.Rd
@@ -32,7 +32,7 @@ around the \code{Message} c++ class that holds the actual message
 as an external pointer.
 }
 \section{Objects from the Class}{
-	Objects are typically created by the \code{new} function invoked
+	Objects are typically created by the \code{new} function invoked 
 	on a \linkS4class{Descriptor} object.
 }
 \section{Slots}{
@@ -43,16 +43,12 @@ as an external pointer.
 }
 \section{Methods}{
   \describe{
-    \item{as.character}{\code{signature(x = "Message")}: returns the debug string of the message.
+    \item{as.character}{\code{signature(x = "Message")}: returns the debug string of the message. 
     This is built from a call to the \code{DebugString} method of the \code{Message} object}
-    \item{toString}{\code{signature(x = "Message")}: same as
-      \code{as.character} }
-    \item{toTextFormat}{\code{signature(x = "Message")}: returns the
-      TextFormat of the message. This is built from a call to
-      \code{TextFormat::PrintToString} with the \code{Message} object.}
-    \item{toDebugString}{\code{signature(x = "Message")}: returns the
-      debug string of the message. This is built from a call to the
-      \code{DebugString} method of the \code{Message} object.}
+    \item{toString}{\code{signature(x = "Message")}: same as \code{as.character} }
+    \item{toTextFormat}{\code{signature(x = "Message")}: returns the TextFormat of the message. 
+    	This is built from a call to \code{TextFormat::PrintToString} with the \code{Message} object}
+    \item{toDebugString}{\code{signature(x = "Message")}: same as \code{as.character} }
     \item{toJSON}{\code{signature(x = "Message")}: returns the JSON representation of the message.
     This is built from a call to the
     \code{google::protobuf::util::MessageToJsonString} method and
@@ -60,20 +56,20 @@ as an external pointer.
     \code{always_print_primitive_fields} - whether to return the default
     value for missing primitive fields (default false)}
     \item{$<-}{\code{signature(x = "Message")}: set the value of a field of the message. }
-    \item{$}{\code{signature(x = "Message")}: gets the value of a field.
-    Primitive types are brought back to R as R objects of the closest matching R type.
+    \item{$}{\code{signature(x = "Message")}: gets the value of a field. 
+    Primitive types are brought back to R as R objects of the closest matching R type. 
     Messages are brought back as instances of the \code{Message} class.}
     \item{[[}{\code{signature(x = "Message")}: extracts a field identified by its name or declared tag number }
     \item{[[<-}{\code{signature(x = "Message")}: replace the value of a field identified by its name or declared tag number }
-	\item{serialize}{\code{signature(object = "Message")}: serialize a message. If the
-    	"connection" argument is \code{NULL}, the payload of the message is returned as a raw vector,
-    	if the "connection" argument is a binary writable connection, the payload is written into the
-       connection. If "connection" is a character vector, the message is sent to
+	\item{serialize}{\code{signature(object = "Message")}: serialize a message. If the 
+    	"connection" argument is \code{NULL}, the payload of the message is returned as a raw vector, 
+    	if the "connection" argument is a binary writable connection, the payload is written into the 
+       connection. If "connection" is a character vector, the message is sent to 
        the file (in binary format). }
     \item{show}{\code{signature(object = "Message")}: displays a short text about the message }
     \item{update}{\code{signature(object = "Message")}: set several fields of the message at once }
-    \item{length}{\code{signature(x = "Message")}: The number of fields actually contained in the message.
-    A field counts in these two situations: the field is repeated and the field size is greater than 0,
+    \item{length}{\code{signature(x = "Message")}: The number of fields actually contained in the message. 
+    A field counts in these two situations: the field is repeated and the field size is greater than 0, 
     the field is not repeated and the message has the field.}
     \item{setExtension}{\code{signature(object = "Message")}: set an
       extension field of the Message.}
@@ -88,19 +84,19 @@ as an external pointer.
 
   }
 }
-\references{
+\references{ 
 	The \code{Message} class from the C++ proto library.
 	\url{https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.message?csw=1}
 }
 \author{ Romain Francois <francoisromain@free.fr> }
 \seealso{
-	\code{\link{P}} creates objects of class \linkS4class{Descriptor} that
-	can be used to create messages.
+	\code{\link{P}} creates objects of class \linkS4class{Descriptor} that 
+	can be used to create messages. 
 }
 \examples{
 \dontrun{
 # example proto file supplied with this package
-proto.file <- system.file( "proto", "addressbook.proto", package = "RProtoBuf" )
+proto.file <- system.file( "proto", "addressbook.proto", package = "RProtoBuf" ) 
 
 # reading a proto file and creating the descriptor
 Person <- P( "tutorial.Person", file = proto.file )
@@ -119,28 +115,28 @@ has( p, "phone" ) # is the "email" field set
 length( p )       # number of fields actually set
 
 # update several fields at once
-romain <- update( new( Person ),
-	email = "francoisromain@free.fr",
-	id = 1,
-	name = "Romain Francois",
+romain <- update( new( Person ), 
+	email = "francoisromain@free.fr", 
+	id = 1, 
+	name = "Romain Francois", 
 	phone = new( PhoneNumber , number = "+33(0)...", type = "MOBILE" )
 	)
 
 # supply parameters to the constructor
-dirk <- new( Person,
-	email = "edd@debian.org",
-	id = 2,
-	name = "Dirk Eddelbuettel" )
+dirk <- new( Person, 
+	email = "edd@debian.org", 
+	id = 2, 
+	name = "Dirk Eddelbuettel" ) 
 # update the phone repeated field with a list of PhoneNumber messages
-dirk$phone <- list(
-	new( PhoneNumber , number = "+01...", type = "MOBILE" ),
+dirk$phone <- list( 
+	new( PhoneNumber , number = "+01...", type = "MOBILE" ), 
 	new( PhoneNumber , number = "+01...", type = "HOME" ) )
-
+	
 # with/within style
 saptarshi <- within( new(Person), {
 	id <- 3
 	name <- "Saptarshi Guha"
-	email <- "saptarshi.guha@gmail.com"
+	email <- "saptarshi.guha@gmail.com" 
 } )
 
 # make an addressbook

--- a/man/Message-class.Rd
+++ b/man/Message-class.Rd
@@ -50,6 +50,9 @@ as an external pointer.
     \item{toTextFormat}{\code{signature(x = "Message")}: returns the
       TextFormat of the message. This is built from a call to
       \code{TextFormat::PrintToString} with the \code{Message} object.}
+    \item{toDebugString}{\code{signature(x = "Message")}: returns the
+      debug string of the message. This is built from a call to the
+      \code{DebugString} method of the \code{Message} object.}
     \item{toJSON}{\code{signature(x = "Message")}: returns the JSON representation of the message.
     This is built from a call to the
     \code{google::protobuf::util::MessageToJsonString} method and

--- a/man/Message-class.Rd
+++ b/man/Message-class.Rd
@@ -32,7 +32,7 @@ around the \code{Message} c++ class that holds the actual message
 as an external pointer.
 }
 \section{Objects from the Class}{
-	Objects are typically created by the \code{new} function invoked 
+	Objects are typically created by the \code{new} function invoked
 	on a \linkS4class{Descriptor} object.
 }
 \section{Slots}{
@@ -43,9 +43,13 @@ as an external pointer.
 }
 \section{Methods}{
   \describe{
-    \item{as.character}{\code{signature(x = "Message")}: returns the debug string of the message. 
+    \item{as.character}{\code{signature(x = "Message")}: returns the debug string of the message.
     This is built from a call to the \code{DebugString} method of the \code{Message} object}
-    \item{toString}{\code{signature(x = "Message")}: same as \code{as.character} }
+    \item{toString}{\code{signature(x = "Message")}: same as
+      \code{as.character} }
+    \item{toTextFormat}{\code{signature(x = "Message")}: returns the
+      TextFormat of the message. This is built from a call to
+      \code{TextFormat::PrintToString} with the \code{Message} object.}
     \item{toJSON}{\code{signature(x = "Message")}: returns the JSON representation of the message.
     This is built from a call to the
     \code{google::protobuf::util::MessageToJsonString} method and
@@ -53,20 +57,20 @@ as an external pointer.
     \code{always_print_primitive_fields} - whether to return the default
     value for missing primitive fields (default false)}
     \item{$<-}{\code{signature(x = "Message")}: set the value of a field of the message. }
-    \item{$}{\code{signature(x = "Message")}: gets the value of a field. 
-    Primitive types are brought back to R as R objects of the closest matching R type. 
+    \item{$}{\code{signature(x = "Message")}: gets the value of a field.
+    Primitive types are brought back to R as R objects of the closest matching R type.
     Messages are brought back as instances of the \code{Message} class.}
     \item{[[}{\code{signature(x = "Message")}: extracts a field identified by its name or declared tag number }
     \item{[[<-}{\code{signature(x = "Message")}: replace the value of a field identified by its name or declared tag number }
-	\item{serialize}{\code{signature(object = "Message")}: serialize a message. If the 
-    	"connection" argument is \code{NULL}, the payload of the message is returned as a raw vector, 
-    	if the "connection" argument is a binary writable connection, the payload is written into the 
-       connection. If "connection" is a character vector, the message is sent to 
+	\item{serialize}{\code{signature(object = "Message")}: serialize a message. If the
+    	"connection" argument is \code{NULL}, the payload of the message is returned as a raw vector,
+    	if the "connection" argument is a binary writable connection, the payload is written into the
+       connection. If "connection" is a character vector, the message is sent to
        the file (in binary format). }
     \item{show}{\code{signature(object = "Message")}: displays a short text about the message }
     \item{update}{\code{signature(object = "Message")}: set several fields of the message at once }
-    \item{length}{\code{signature(x = "Message")}: The number of fields actually contained in the message. 
-    A field counts in these two situations: the field is repeated and the field size is greater than 0, 
+    \item{length}{\code{signature(x = "Message")}: The number of fields actually contained in the message.
+    A field counts in these two situations: the field is repeated and the field size is greater than 0,
     the field is not repeated and the message has the field.}
     \item{setExtension}{\code{signature(object = "Message")}: set an
       extension field of the Message.}
@@ -81,19 +85,19 @@ as an external pointer.
 
   }
 }
-\references{ 
+\references{
 	The \code{Message} class from the C++ proto library.
 	\url{https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.message?csw=1}
 }
 \author{ Romain Francois <francoisromain@free.fr> }
 \seealso{
-	\code{\link{P}} creates objects of class \linkS4class{Descriptor} that 
-	can be used to create messages. 
+	\code{\link{P}} creates objects of class \linkS4class{Descriptor} that
+	can be used to create messages.
 }
 \examples{
 \dontrun{
 # example proto file supplied with this package
-proto.file <- system.file( "proto", "addressbook.proto", package = "RProtoBuf" ) 
+proto.file <- system.file( "proto", "addressbook.proto", package = "RProtoBuf" )
 
 # reading a proto file and creating the descriptor
 Person <- P( "tutorial.Person", file = proto.file )
@@ -112,28 +116,28 @@ has( p, "phone" ) # is the "email" field set
 length( p )       # number of fields actually set
 
 # update several fields at once
-romain <- update( new( Person ), 
-	email = "francoisromain@free.fr", 
-	id = 1, 
-	name = "Romain Francois", 
+romain <- update( new( Person ),
+	email = "francoisromain@free.fr",
+	id = 1,
+	name = "Romain Francois",
 	phone = new( PhoneNumber , number = "+33(0)...", type = "MOBILE" )
 	)
 
 # supply parameters to the constructor
-dirk <- new( Person, 
-	email = "edd@debian.org", 
-	id = 2, 
-	name = "Dirk Eddelbuettel" ) 
+dirk <- new( Person,
+	email = "edd@debian.org",
+	id = 2,
+	name = "Dirk Eddelbuettel" )
 # update the phone repeated field with a list of PhoneNumber messages
-dirk$phone <- list( 
-	new( PhoneNumber , number = "+01...", type = "MOBILE" ), 
+dirk$phone <- list(
+	new( PhoneNumber , number = "+01...", type = "MOBILE" ),
 	new( PhoneNumber , number = "+01...", type = "HOME" ) )
-	
+
 # with/within style
 saptarshi <- within( new(Person), {
 	id <- 3
 	name <- "Saptarshi Guha"
-	email <- "saptarshi.guha@gmail.com" 
+	email <- "saptarshi.guha@gmail.com"
 } )
 
 # make an addressbook

--- a/src/init.c
+++ b/src/init.c
@@ -136,6 +136,7 @@ extern SEXP Message__is_initialized(SEXP);
 extern SEXP Message__length(SEXP);
 extern SEXP Message__merge(SEXP, SEXP);
 extern SEXP Message__num_extensions(SEXP);
+extern SEXP Message__print_text_format(SEXP);
 extern SEXP Message__serialize_to_file(SEXP, SEXP);
 extern SEXP Message__set_field_size(SEXP, SEXP, SEXP);
 extern SEXP Message__set_field_values(SEXP, SEXP, SEXP, SEXP);
@@ -296,6 +297,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"Message__merge",                           (DL_FUNC) &Message__merge,                            2},
     {"Message__num_extensions",                  (DL_FUNC) &Message__num_extensions,                   1},
     {"Message__serialize_to_file",               (DL_FUNC) &Message__serialize_to_file,                2},
+    {"Message__print_text_format",               (DL_FUNC) &Message__print_text_format,                1},
     {"Message__set_field_size",                  (DL_FUNC) &Message__set_field_size,                   3},
     {"Message__set_field_values",                (DL_FUNC) &Message__set_field_values,                 4},
     {"Message__swap",                            (DL_FUNC) &Message__swap,                             4},

--- a/src/wrapper_Message.cpp
+++ b/src/wrapper_Message.cpp
@@ -1179,4 +1179,13 @@ RPB_FUNCTION_VOID_4(METHOD(set_field_values), Rcpp::XPtr<GPB::Message> message, 
 
 #undef METHOD
 
+/**
+ * Return the TextFormat of message
+ * @param xp external pointer to the Message
+ */
+RPB_FUNCTION_1(std::string, METHOD(print_text_format),
+               Rcpp::XPtr<GPB::Message> message) {
+  std::string message_text;
+  GPB::TextFormat::PrintToString(*message, &message_text);
+  return message_text;
 }


### PR DESCRIPTION
Closes #87 

Still WIP. Filing because our build system doesn't make it easy to compile locally -- relying on CI to get the i's dotted / t's crossed. Feedback on minor things (whitespace/style/etc) welcome.

The basic outline laid out here is:

(1) A new `toTextFormat()` method to directly convert to `TextFormat` equivalent `character`
(2) A corresponding new `toDebugFormat()` that's equivalent to the current `toString()` / `as.character()` defaults
(3) A new argument `debug` to `toString()` that defaults to an option that we can use to aid in deprecation. `debug=TRUE` ➡️ same as current `toString()` behavior; `debug=FALSE` ➡️ same as `toTextFormat()`

For now added the two new methods as an aid to non-R devs who end up maintaining some R code, it should be easier for them to understand how these methods correspond to the C++ API, whereas the `toString()` argument toggle will be more familiar to primarily R devs. 