### PR TITLE
Make `rprotobuf` compatible with `protobuf` >= 22.x

### DIFF
--- a/.github/workflows/alpine.yaml
+++ b/.github/workflows/alpine.yaml
@@ -1,0 +1,28 @@
+## Run CI under Alpine 3.19 to test with much newer Protocol Buffers
+## Cf https://github.com/eddelbuettel/rprotobuf/issues/95
+
+name: alpine
+
+on:
+  push:
+  pull_request:
+  release:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.19
+    steps:
+      - uses: actions/checkout@v4
+      - name: System Dependencies
+        run: apk add --no-cache R R-doc R-dev g++ protobuf-dev
+      - name: Session Info
+        run: R -q -e 'sessionInfo()'
+      - name: Package Dependencies
+        run: R -q -e 'install.packages(c("Rcpp", "tinytest"), repos="https://cloud.r-project.org")'
+      - name: Build Package
+        run: R CMD build --no-build-vignettes --no-manual .
+      - name: Check Package
+        run: R CMD check --no-vignettes --no-manual $(ls -1tr *.tar.gz | tail -1)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2023-07-11  Matteo Gianella  <matteo.gianella@polimi.it>
+
+	* src/RSourceTree.h: Code update also in case of protobuf version >= 22.x
+	* src/RSourceTree.h: Idem
+	* src/wrapper_Descriptor: Idem
+	* src/wrapper_Descriptor: Idem
+
 2023-03-11  Dirk Eddelbuettel  <edd@debian.org>
 
 	* src/Makevars.ucrt (CXX_STD): Also set C++17 here

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,9 @@
-2023-07-11  Matteo Gianella  <matteo.gianella@polimi.it>
+2023-07-12  Matteo Gianella  <matteo.gianella@polimi.it>
 
 	* src/RSourceTree.h: Code update also in case of protobuf version >= 22.x
-	* src/RSourceTree.h: Idem
+	* src/RSourceTree.cpp: Idem
 	* src/wrapper_Descriptor: Idem
-	* src/wrapper_Descriptor: Idem
+	* src/wrapper_Message: Idem
 
 2023-03-11  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-12-09  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .github/workflows/alpine.yaml: Add container-based continuous
+	integration test to permit test under newer Protocol Buffers
+
 2023-07-12  Matteo Gianella  <matteo.gianella@polimi.it>
 
 	* src/RSourceTree.h: Code update also in case of protobuf version >= 22.x

--- a/src/RSourceTree.cpp
+++ b/src/RSourceTree.cpp
@@ -6,6 +6,7 @@ namespace rprotobuf {
 
 RSourceTree::RSourceTree() : directories() {}
 
+#if PROTOBUF_VERSION >= 4022000
 GPB::io::ZeroCopyInputStream* RSourceTree::Open(const std::string& filename) {
     /* first, try to open the file as it is */
     int file_descriptor = open(filename.c_str(), O_RDONLY);
@@ -32,6 +33,34 @@ GPB::io::ZeroCopyInputStream* RSourceTree::Open(const std::string& filename) {
     result->SetCloseOnDelete(true);
     return result;
 }
+#else
+GPB::io::ZeroCopyInputStream* RSourceTree::Open(absl::string_view filename) {
+    /* first, try to open the file as it is */
+    int file_descriptor = open(static_cast<std::string>(filename).c_str(), O_RDONLY);
+    if (file_descriptor < 0) {
+        /* then try the directories */
+        std::set<std::string>::iterator it;
+        it = directories.begin();
+        std::string file;
+        while (it != directories.end()) {
+            file = *it;
+            file += "/";
+            file += static_cast<std::string>(filename);
+            file_descriptor = open(file.c_str(), O_RDONLY);
+            if (file_descriptor > 0) break;
+            ++it;
+        }
+    }
+
+    if (file_descriptor < 0) {
+        return NULL;
+    }
+
+    GPB::io::FileInputStream* result = new GPB::io::FileInputStream(file_descriptor);
+    result->SetCloseOnDelete(true);
+    return result;
+}
+#endif
 
 void RSourceTree::addDirectory(const std::string& directory) { directories.insert(directory); }
 void RSourceTree::addDirectories(SEXP dirs) {

--- a/src/RSourceTree.cpp
+++ b/src/RSourceTree.cpp
@@ -6,7 +6,7 @@ namespace rprotobuf {
 
 RSourceTree::RSourceTree() : directories() {}
 
-#if PROTOBUF_VERSION >= 4022000
+#if GOOGLE_PROTOBUF_VERSION < 4022000
 GPB::io::ZeroCopyInputStream* RSourceTree::Open(const std::string& filename) {
     /* first, try to open the file as it is */
     int file_descriptor = open(filename.c_str(), O_RDONLY);

--- a/src/RSourceTree.h
+++ b/src/RSourceTree.h
@@ -5,11 +5,11 @@ namespace rprotobuf {
 class RSourceTree : public GPB::compiler::SourceTree {
    public:
     RSourceTree();
-#if PROTOBUF_VERSION >= 4022000
-    GPB::io::ZeroCopyInputStream* Open(const std::string& filename);
-#else
-    GPB::io::ZeroCopyInputStream* Open(absl::string_view filename);
-#endif
+    #if GOOGLE_PROTOBUF_VERSION < 4022000
+        GPB::io::ZeroCopyInputStream* Open(const std::string& filename);
+    #else
+        GPB::io::ZeroCopyInputStream* Open(absl::string_view filename);
+    #endif
     void addDirectory(const std::string& directory);
     void addDirectories(SEXP dirs);
     void removeDirectory(const std::string& directory);

--- a/src/RSourceTree.h
+++ b/src/RSourceTree.h
@@ -5,7 +5,11 @@ namespace rprotobuf {
 class RSourceTree : public GPB::compiler::SourceTree {
    public:
     RSourceTree();
+#if PROTOBUF_VERSION >= 4022000
     GPB::io::ZeroCopyInputStream* Open(const std::string& filename);
+#else
+    GPB::io::ZeroCopyInputStream* Open(absl::string_view filename);
+#endif
     void addDirectory(const std::string& directory);
     void addDirectories(SEXP dirs);
     void removeDirectory(const std::string& directory);

--- a/src/wrapper_Descriptor.cpp
+++ b/src/wrapper_Descriptor.cpp
@@ -232,11 +232,11 @@ RPB_FUNCTION_2(S4_Message, METHOD(readJSONFromString), Rcpp::XPtr<GPB::Descripto
     if (!message) {
         Rcpp::stop("could not call factory->GetPrototype(desc)->New()");
     }
-#if PROTOBUF_VERSION >= 4022000
-    GPB::util::Status status = GPB::util::JsonStringToMessage(input, message);
-#else
-    absl::Status status = GPB::util::JsonStringToMessage(input, message);
-#endif
+    #if GOOGLE_PROTOBUF_VERSION < 4022000
+        GPB::util::Status status = GPB::util::JsonStringToMessage(input, message);
+    #else
+        absl::Status status = GPB::util::JsonStringToMessage(input, message);
+    #endif
     if (!status.ok()) {
         Rcpp::stop(status.ToString().c_str());
     }
@@ -268,7 +268,7 @@ RPB_FUNCTION_2(S4_Message, METHOD(readJSONFromConnection), Rcpp::XPtr<GPB::Descr
     if (!message) {
         Rcpp::stop("could not call factory->GetPrototype(desc)->New()");
     }
-    #if PROTOBUF_VERSION >= 4022000
+    #if GOOGLE_PROTOBUF_VERSION < 4022000
         GPB::util::Status status = GPB::util::JsonStringToMessage(json_string, message);
     #else
         absl::Status status = GPB::util::JsonStringToMessage(json_string, message);

--- a/src/wrapper_Descriptor.cpp
+++ b/src/wrapper_Descriptor.cpp
@@ -232,8 +232,11 @@ RPB_FUNCTION_2(S4_Message, METHOD(readJSONFromString), Rcpp::XPtr<GPB::Descripto
     if (!message) {
         Rcpp::stop("could not call factory->GetPrototype(desc)->New()");
     }
-
+#if PROTOBUF_VERSION >= 4022000
     GPB::util::Status status = GPB::util::JsonStringToMessage(input, message);
+#else
+    absl::Status status = GPB::util::JsonStringToMessage(input, message);
+#endif
     if (!status.ok()) {
         Rcpp::stop(status.ToString().c_str());
     }
@@ -265,7 +268,11 @@ RPB_FUNCTION_2(S4_Message, METHOD(readJSONFromConnection), Rcpp::XPtr<GPB::Descr
     if (!message) {
         Rcpp::stop("could not call factory->GetPrototype(desc)->New()");
     }
-    GPB::util::Status status = GPB::util::JsonStringToMessage(json_string, message);
+    #if PROTOBUF_VERSION >= 4022000
+        GPB::util::Status status = GPB::util::JsonStringToMessage(json_string, message);
+    #else
+        absl::Status status = GPB::util::JsonStringToMessage(json_string, message);
+    #endif
     if (!status.ok()) {
         Rcpp::stop(status.ToString().c_str());
     }

--- a/src/wrapper_Message.cpp
+++ b/src/wrapper_Message.cpp
@@ -454,7 +454,7 @@ RPB_FUNCTION_3(Rcpp::CharacterVector, METHOD(as_json), Rcpp::XPtr<GPB::Message> 
     opts.always_print_primitive_fields = always_print_primitive_fields;
 
     std::string buf;
-    #if PROTOBUF_VERSION >= 4022000
+    #if GOOGLE_PROTOBUF_VERSION < 4022000
         GPB::util::Status status = GPB::util::MessageToJsonString(*message, &buf, opts);
     #else
         absl::Status status = GPB::util::MessageToJsonString(*message, &buf, opts);

--- a/src/wrapper_Message.cpp
+++ b/src/wrapper_Message.cpp
@@ -454,7 +454,11 @@ RPB_FUNCTION_3(Rcpp::CharacterVector, METHOD(as_json), Rcpp::XPtr<GPB::Message> 
     opts.always_print_primitive_fields = always_print_primitive_fields;
 
     std::string buf;
-    GPB::util::Status status = GPB::util::MessageToJsonString(*message, &buf, opts);
+    #if PROTOBUF_VERSION >= 4022000
+        GPB::util::Status status = GPB::util::MessageToJsonString(*message, &buf, opts);
+    #else
+        absl::Status status = GPB::util::MessageToJsonString(*message, &buf, opts);
+    #endif
     if (!status.ok()) {
         Rcpp::stop(status.ToString().c_str());
     }


### PR DESCRIPTION
This should close #92 

Still a WIP.

I tried to manage both cases introducing a preprocessor directive checking the version of `protobuf`. I tried to preserve as much as possible the existing code. Maybe we can improve `src/RSourceTree.h`/`src/RSourceTree.cpp`, since a lot of code is re-used.

On my machine (Arch Linux, `gcc` 13.1.1, `protobuf` 23.4-1) now the compilation is successfull. I have also tested compilation on Ubuntu 20.04 with `protobuf` 3.14.0, which relies on the old API.