### PR TITLE
Tidy: use internal concatenation to build error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-05-28  Michael Chirico  <chiricom@google.com>
+
+	* R/extensions.R: Build error strings with stop(), avoiding paste()
+
 2024-05-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Use tinyverse.netlify.app for dependency badge

--- a/R/extensions.R
+++ b/R/extensions.R
@@ -25,7 +25,7 @@ setMethod( "setExtension", "Message", function( object, field, values ){
 		stop("setExtension requires a FieldDescriptor")
 	}
 	if (!is_extension(field)) {
-		stop(paste(name(field), "is not an extension FieldDescriptor."))
+		stop(name(field), " is not an extension FieldDescriptor.")
 	}
 	.Call(setMessageField, object@pointer, field, values)
 	invisible( object )
@@ -40,15 +40,13 @@ setMethod( "getExtension", "Message", function( object, field){
 		stop("getExtension requires a FieldDescriptor")
 	}
 	if (!is_extension(field)) {
-		stop(paste(name(field), "is not an extension FieldDescriptor."))
+		stop(name(field), " is not an extension FieldDescriptor.")
 	}
 	# This check causes a CHECK failure in the C++ code, so give
 	# a more user-friendly error here.
 	if (containing_type(field)@type != object@type) {
-		stop(paste("Field", name(field),
-			   "does not match message type (",
-			   containing_type(field)@type, "!=",
-			   object@type, ")"))
+		stop("Field", name(field), " does not match message type ",
+             "(", containing_type(field)@type, "!=", object@type, ")")
 	}
     .Call(getExtension_cpp, object@pointer, field)
 } )


### PR DESCRIPTION
As found by [`condition_message_linter()`](https://lintr.r-lib.org/reference/condition_message_linter.html).

We might also prefer `gettextf()` for internationalization but that's a much bigger project.