### PR TITLE
Remove placeholders for missing routines

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-05-28  Michael Chirico  <chiricom@google.com>
+
+	* src/init.c: Remove placeholders for unimplemented methods
+	* R/00classes.R: Idem
+	* R/field_count.R: Idem
+	* R/wrapper_ServiceDescriptor.R: Idem
+
 2024-05-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Use tinyverse.netlify.app for dependency badge

--- a/R/00classes.R
+++ b/R/00classes.R
@@ -288,7 +288,7 @@ setMethod( "$", "ServiceDescriptor", function(x, name ){
 		"method_count" = function() method_count(x),
 		"method" = function(...) method(x, ... ),
 
-		.Call("ServiceDescriptor__method", x@pointer, name)
+		stop( "No '", name, "' method for ServiceDescriptor objects is implemented." )
 		)
 } )
 
@@ -448,7 +448,7 @@ setMethod("[[", "ServiceDescriptor", function(x, i, j, ..., exact = TRUE){
 		warning( "`j` is ignored" )
 	}
 	if( is.character( i ) || is.numeric( i ) ){
-		.Call("ServiceDescriptor__method", x@pointer, name )
+		stop( "No '", name, "' method for ServiceDescriptor objects is implemented." )
 	} else{
 		stop( "wrong type, `i` should be a character or a number" )
 	}

--- a/R/field_count.R
+++ b/R/field_count.R
@@ -79,7 +79,7 @@ setMethod( "enum_type", "Descriptor", function(object, index, name){
 	}
 
 	if( has_name ){
-		return(.Call("Descriptor__FindEnumTypeByName", object@pointer, as.character(name) ) )
+		stop( "No routine for finding enum type of a Descriptor by name. ")
 	}
 
 })

--- a/R/wrapper_ServiceDescriptor.R
+++ b/R/wrapper_ServiceDescriptor.R
@@ -19,11 +19,11 @@ setMethod( "method", "ServiceDescriptor", function(object, index, name){
 	}
 
 	if( has_index ){
-		return(.Call("ServiceDescriptor_getMethodByIndex", object@pointer, as.integer(index)-1L ) )
+		stop( "No routine for getting a method from a ServiceDescriptor by index." )
 	}
 
 	if( has_name ){
-		return(.Call("ServiceDescriptor_getMethodByName", object@pointer, as.character(name) ) )
+		stop( "No routine for getting a method from a ServiceDescriptor by name." )
 	}
 
 } )

--- a/src/init.c
+++ b/src/init.c
@@ -40,7 +40,6 @@ extern SEXP Descriptor__enum_type_count(SEXP);
 extern SEXP Descriptor__field(SEXP, SEXP);
 extern SEXP Descriptor__field_count(SEXP);
 extern SEXP Descriptor__fileDescriptor(SEXP);
-/*extern SEXP Descriptor__FindEnumTypeByName(SEXP, SEXP);*/
 extern SEXP Descriptor__FindFieldByName(SEXP, SEXP);
 extern SEXP Descriptor__FindFieldByNumber(SEXP, SEXP);
 extern SEXP Descriptor__FindNestedTypeByName(SEXP, SEXP);
@@ -156,10 +155,7 @@ extern SEXP ServiceDescriptor__as_list(SEXP);
 extern SEXP ServiceDescriptor__as_Message(SEXP);
 extern SEXP ServiceDescriptor__fileDescriptor(SEXP);
 extern SEXP ServiceDescriptor__getMethodNames(SEXP);
-/*extern SEXP ServiceDescriptor__method(SEXP, SEXP);*/
 extern SEXP ServiceDescriptor__name(SEXP, SEXP);
-/*extern SEXP ServiceDescriptor_getMethodByIndex(SEXP, SEXP);*/
-/*extern SEXP ServiceDescriptor_getMethodByName(SEXP, SEXP);*/
 /*extern SEXP ServiceDescriptor_method_count(SEXP);*/
 extern SEXP setMessageField(SEXP, SEXP, SEXP);
 extern SEXP update_message(SEXP, SEXP);
@@ -200,7 +196,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"Descriptor__field",                        (DL_FUNC) &Descriptor__field,                         2},
     {"Descriptor__field_count",                  (DL_FUNC) &Descriptor__field_count,                   1},
     {"Descriptor__fileDescriptor",               (DL_FUNC) &Descriptor__fileDescriptor,                1},
-/*    {"Descriptor__FindEnumTypeByName",           (DL_FUNC) &Descriptor__FindEnumTypeByName,            2}, */
     {"Descriptor__FindFieldByName",              (DL_FUNC) &Descriptor__FindFieldByName,               2},
     {"Descriptor__FindFieldByNumber",            (DL_FUNC) &Descriptor__FindFieldByNumber,             2},
     {"Descriptor__FindNestedTypeByName",         (DL_FUNC) &Descriptor__FindNestedTypeByName,          2},
@@ -316,10 +311,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"ServiceDescriptor__as_Message",            (DL_FUNC) &ServiceDescriptor__as_Message,             1},
     {"ServiceDescriptor__fileDescriptor",        (DL_FUNC) &ServiceDescriptor__fileDescriptor,         1},
     {"ServiceDescriptor__getMethodNames",        (DL_FUNC) &ServiceDescriptor__getMethodNames,         1},
-/*    {"ServiceDescriptor__method",                (DL_FUNC) &ServiceDescriptor__method,                 2},*/
     {"ServiceDescriptor__name",                  (DL_FUNC) &ServiceDescriptor__name,                   2},
-/*    {"ServiceDescriptor_getMethodByIndex",       (DL_FUNC) &ServiceDescriptor_getMethodByIndex,        2},*/
-/*    {"ServiceDescriptor_getMethodByName",        (DL_FUNC) &ServiceDescriptor_getMethodByName,         2},*/
 /*    {"ServiceDescriptor_method_count",           (DL_FUNC) &ServiceDescriptor_method_count,            1},*/
     {"setMessageField",                          (DL_FUNC) &setMessageField,                           3},
     {"update_message",                           (DL_FUNC) &update_message,                            2},


### PR DESCRIPTION
Closes #101

I left the placeholder for `ServiceDescriptor_method_count` since I reckon that's pretty easy to implement, I just haven't bothered staring long enough at the macros yet :)