### PR TITLE
`RProtoBuf` compatible with `protobuf` >= 26.x

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-07-02  Matteo Gianella  <matteo.gianella@polimi.it>
+
+	* src/RWarningErrorCollector.h: Code update also in case of protobuf version >= 26.x
+	* src/RWarningErrorCollector.cpp: Idem
+	* src/wrapper_Message: Idem
+
 2024-05-29  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/src/RWarningErrorCollector.cpp
+++ b/src/RWarningErrorCollector.cpp
@@ -4,10 +4,18 @@
 
 namespace rprotobuf {
 
-void RWarningErrorCollector::AddError(const std::string& filename, int line, int column,
-                                      const std::string& message) {
+#if GOOGLE_PROTOBUF_VERSION < 5026000
+    void RWarningErrorCollector::AddError(const std::string& filename, int line, int column,
+                                          const std::string& message) {
 
-    Rprintf("%s:%d:%d:%s\n", filename.c_str(), line + 1, column + 1, message.c_str());
-}
+        Rprintf("%s:%d:%d:%s\n", filename.c_str(), line + 1, column + 1, message.c_str());
+    }
+#else
+    void RWarningErrorCollector::RecordError(absl::string_view filename, int line, int column,
+                                             absl::string_view message) {
+
+        Rprintf("%s:%d:%d:%s\n", std::string(filename).c_str(), line + 1, column + 1, std::string(message).c_str());
+    }
+#endif
 
 }  // namespace rprotobuf

--- a/src/RWarningErrorCollector.h
+++ b/src/RWarningErrorCollector.h
@@ -7,7 +7,11 @@ namespace rprotobuf {
 class RWarningErrorCollector : public GPB::compiler::MultiFileErrorCollector {
    public:
     // implements ErrorCollector ---------------------------------------
-    void AddError(const std::string& filename, int line, int column, const std::string& message);
+    #if GOOGLE_PROTOBUF_VERSION < 5026000
+        void AddError(const std::string& filename, int line, int column, const std::string& message);
+    #else
+        void RecordError(absl::string_view filename, int line, int column, absl::string_view message);
+    #endif
 };
 
 }  // namespace rprotobuf

--- a/src/wrapper_Message.cpp
+++ b/src/wrapper_Message.cpp
@@ -451,7 +451,9 @@ RPB_FUNCTION_3(Rcpp::CharacterVector, METHOD(as_json), Rcpp::XPtr<GPB::Message> 
     GPB::util::JsonPrintOptions opts;
     opts.add_whitespace = true;
     opts.preserve_proto_field_names = preserve_proto_field_names;
-    opts.always_print_primitive_fields = always_print_primitive_fields;
+    #if GOOGLE_PROTOBUF_VERSION < 5026000
+        opts.always_print_primitive_fields = always_print_primitive_fields;
+    #endif
 
     std::string buf;
     #if GOOGLE_PROTOBUF_VERSION < 4022000


### PR DESCRIPTION
As stated in the Release Notes, `protobuf` version 26.0 includes breaking changes to `C++` and other languages.
This causes `RProtoBuf` fail to get installed in case the version of `protobuf` is up to latest release.

This PR makes `RProtoBuf` compatible with this new changes in the code.

**NOTE** In `wrapper_Message.cpp` in this new version the `always_print_primitive_fields` has been removed. I personally did the minimal effort to make the package up and running, but maybe some additional work should be done.

Hope it helps.