### PR TITLE
Make RProtoBuf compatible with protobuf >= 6.30.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,19 @@
+2024-11-11  Lev Kandel  <lmakhlis@google.com>
+
+	* src/DescriptorPoolLookup.cpp: Compatibility with protobuf >= 6.30.0
+	* src/DescriptorPoolLookup.h: Idem
+	* src/mutators.cpp: Idem
+	* src/rprotobuf.cpp: Idem
+	* src/rprotobuf.h: Idem
+	* src/wrapper_Descriptor.cpp: Idem
+	* src/wrapper_EnumDescriptor.cpp: Idem
+	* src/wrapper_EnumValueDescriptor.cpp: Idem
+	* src/wrapper_FieldDescriptor.cpp: Idem
+	* src/wrapper_FileDescriptor.cpp: Idem
+	* src/wrapper_Message.cpp: Idem
+	* src/wrapper_MethodDescriptor.cpp: Idem
+	* src/wrapper_ServiceDescriptor.cpp: Idem
+
 2024-11-07  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Authors@R): Added

--- a/src/DescriptorPoolLookup.cpp
+++ b/src/DescriptorPoolLookup.cpp
@@ -23,15 +23,15 @@
 
 namespace rprotobuf {
 
-void DescriptorPoolLookup::add(const std::string& element) { elements.insert(element); }
+void DescriptorPoolLookup::add(std::string_view element) { elements.emplace(element); }
 
-bool DescriptorPoolLookup::contains(const std::string& element) {
+bool DescriptorPoolLookup::contains(std::string_view element) {
     return elements.find(element) != elements.end();
 }
 
 SEXP DescriptorPoolLookup::getElements() { return Rcpp::wrap(elements); }
 
-std::set<std::string> DescriptorPoolLookup::elements;
+std::set<std::string, std::less<>> DescriptorPoolLookup::elements;
 RWarningErrorCollector DescriptorPoolLookup::error_collector;
 RSourceTree DescriptorPoolLookup::source_tree;
 GPB::compiler::Importer* DescriptorPoolLookup::importer =

--- a/src/DescriptorPoolLookup.h
+++ b/src/DescriptorPoolLookup.h
@@ -1,8 +1,10 @@
 #ifndef RPROTOBUF_DescriptorPoolLookup_H
 #define RPROTOBUF_DescriptorPoolLookup_H
 
+#include <functional>           /* For less */
 #include <set>                  /* For set */
 #include <string>               /* For string */
+#include <string_view>          /* For string_view */
 
 #include "RSourceTree.h"
 #include "RWarningErrorCollector.h"
@@ -11,9 +13,9 @@ namespace rprotobuf {
 
 class DescriptorPoolLookup {
    public:
-    static void add(const std::string& element);
+    static void add(std::string_view element);
 
-    static bool contains(const std::string& element);
+    static bool contains(std::string_view element);
 
     static SEXP getElements();
 
@@ -26,7 +28,7 @@ class DescriptorPoolLookup {
     static const GPB::DynamicMessageFactory* factory();
 
    private:
-    static std::set<std::string> elements;
+    static std::set<std::string, std::less<>> elements;
     static RWarningErrorCollector error_collector;
     static RSourceTree source_tree;
     static GPB::compiler::Importer* importer;

--- a/src/mutators.cpp
+++ b/src/mutators.cpp
@@ -359,7 +359,7 @@ void CHECK_messages(const GPB::FieldDescriptor* field_desc, SEXP values) {
         Rcpp::stop("expecting a list of messages");
     }
 
-    const char* target = field_desc->message_type()->full_name().c_str();
+    std::string_view target = field_desc->message_type()->full_name();
     int n = LENGTH(values);
     for (int i = 0; i < n; i++) {
         if (!isMessage(VECTOR_ELT(values, i), target)) {
@@ -372,7 +372,8 @@ void CHECK_messages(const GPB::FieldDescriptor* field_desc, SEXP values) {
             s = out.str();
             // }}}
             std::string message = "List element " + s + " is not a message " +
-                             "of the appropriate type ('" + target + "')";
+                                  "of the appropriate type ('" +
+                                  std::string(target) + "')";
             Rcpp::stop(message.c_str());
         }
     }
@@ -397,10 +398,13 @@ void CHECK_repeated_vals(const GPB::FieldDescriptor* field_desc, SEXP value, int
                 }
                 case S4SXP: {
                     /* check that this is a message of the appropriate type */
-                    if (!isMessage(value, field_desc->message_type()->full_name().c_str())) {
-                        std::string message = "Not a message of type '" +
-                                         field_desc->message_type()->full_name() + "'";
-                        Rcpp::stop(message.c_str());
+                    if (!isMessage(value,
+                                   field_desc->message_type()->full_name())) {
+                      std::string message =
+                          "Not a message of type '" +
+                          std::string(field_desc->message_type()->full_name()) +
+                          "'";
+                      Rcpp::stop(message.c_str());
                     }
                     break;
                 }
@@ -627,9 +631,9 @@ void setNonRepeatedMessageField(GPB::Message* message, const Reflection* ref,
             if (TYPEOF(value) == S4SXP && Rf_inherits(value, "Message")) {
                 GPB::Message* mess =
                     (GPB::Message*)EXTPTR_PTR(GET_SLOT(value, Rf_install("pointer")));
-                const char* type = mess->GetDescriptor()->full_name().c_str();
-                const char* target = field_desc->message_type()->full_name().c_str();
-                if (strcmp(type, target)) {
+                std::string_view type = mess->GetDescriptor()->full_name();
+                std::string_view target = field_desc->message_type()->full_name();
+                if (type != target) {
                     Rcpp::stop("wrong message type");
                 }
                 GPB::Message* m = ref->MutableMessage(message, field_desc);

--- a/src/rprotobuf.cpp
+++ b/src/rprotobuf.cpp
@@ -240,16 +240,16 @@ RcppExport SEXP do_dollar_Descriptor(SEXP pointer, SEXP name) {
  *
  * @return TRUE if m is a a message of the given type
  */
-Rboolean isMessage(SEXP m, const char* target) {
+Rboolean isMessage(SEXP m, std::string_view target) {
     RPB_DEBUG_BEGIN("isMessage")
 
     if (TYPEOF(m) != S4SXP || !Rf_inherits(m, "Message")) return _FALSE_;
 
     GPB::Message* message = (GPB::Message*)EXTPTR_PTR(GET_SLOT(m, Rf_install("pointer")));
 
-    const char* type = message->GetDescriptor()->full_name().c_str();
+    std::string_view type = message->GetDescriptor()->full_name();
     RPB_DEBUG_END("isMessage")
-    if (strcmp(type, target)) {
+    if (type != target) {
         return _FALSE_;
     }
     return _TRUE_;

--- a/src/rprotobuf.h
+++ b/src/rprotobuf.h
@@ -26,6 +26,7 @@
 #include <string.h>  // for strerror
 #include <unistd.h>  // g++-4.7 wants this
 #include <string>    // for string
+#include <string_view>
 // O_BINARY does not exist on Unix/Linux, since there is no distinction
 // between text mode and binary mode files there, but if we ever got
 // this code running on Windows this would be needed.
@@ -141,7 +142,7 @@ RcppExport SEXP newProtoMessage(SEXP);
 RcppExport SEXP getProtobufDescriptor(SEXP);
 RcppExport SEXP getExtensionDescriptor(SEXP);
 RcppExport SEXP readProtoFiles_cpp(SEXP, SEXP);
-RcppExport Rboolean isMessage(SEXP, const char*);
+RcppExport Rboolean isMessage(SEXP, std::string_view);
 RcppExport GPB::FieldDescriptor* getFieldDescriptor(const GPB::Message*, SEXP);
 
 /* in extractors.cpp */

--- a/src/wrapper_Descriptor.cpp
+++ b/src/wrapper_Descriptor.cpp
@@ -31,13 +31,13 @@ RPB_FUNCTION_1(Rcpp::CharacterVector, METHOD(getMemberNames), Rcpp::XPtr<GPB::De
     Rcpp::CharacterVector res(nfields + ntypes + nenums);
     int j = 0;
     for (int i = 0; i < nfields; i++, j++) {
-        res[j] = desc->field(i)->name();
+        res[j] = std::string(desc->field(i)->name());
     }
     for (int i = 0; i < ntypes; i++, j++) {
-        res[j] = desc->nested_type(i)->name();
+        res[j] = std::string(desc->nested_type(i)->name());
     }
     for (int i = 0; i < nenums; i++, j++) {
-        res[j] = desc->enum_type(i)->name();
+        res[j] = std::string(desc->enum_type(i)->name());
     }
     return (res);
 }
@@ -59,17 +59,17 @@ RPB_FUNCTION_1(Rcpp::List, METHOD(as_list), Rcpp::XPtr<GPB::Descriptor> desc) {
     for (int i = 0; i < nfields; cnt++, i++) {
         const GPB::FieldDescriptor* fd = desc->field(i);
         res[cnt] = S4_FieldDescriptor(fd);
-        names[cnt] = fd->name();
+        names[cnt] = std::string(fd->name());
     }
     for (int i = 0; i < ntypes; cnt++, i++) {
         const GPB::Descriptor* d = desc->nested_type(i);
         res[cnt] = S4_Descriptor(d);
-        names[cnt] = d->name();
+        names[cnt] = std::string(d->name());
     }
     for (int i = 0; i < nenums; cnt++, i++) {
         const GPB::EnumDescriptor* ed = desc->enum_type(i);
         res[cnt] = S4_EnumDescriptor(ed);
-        names[cnt] = ed->name();
+        names[cnt] = std::string(ed->name());
     }
     res.names() = names;
 
@@ -120,7 +120,7 @@ RPB_FUNCTION_1(S4_FileDescriptor, METHOD(fileDescriptor), Rcpp::XPtr<GPB::Descri
 }
 
 RPB_FUNCTION_2(std::string, METHOD(name), Rcpp::XPtr<GPB::Descriptor> d, bool full) {
-    return full ? d->full_name() : d->name();
+    return std::string(full ? d->full_name() : d->name());
 }
 
 RPB_FUNCTION_2(S4_Message, METHOD(readMessageFromFile), Rcpp::XPtr<GPB::Descriptor> desc,

--- a/src/wrapper_EnumDescriptor.cpp
+++ b/src/wrapper_EnumDescriptor.cpp
@@ -107,7 +107,7 @@ RPB_FUNCTION_1(Rcpp::List, METHOD(as_list), Rcpp::XPtr<GPB::EnumDescriptor> d) {
     for (int i = 0; i < n; i++) {
         const GPB::EnumValueDescriptor* value_d = d->value(i);
         res[i] = value_d->number();
-        names[i] = value_d->name();
+        names[i] = std::string(value_d->name());
     }
     res.names() = names;
     return res;
@@ -117,7 +117,7 @@ RPB_FUNCTION_1(Rcpp::CharacterVector, METHOD(getConstantNames), Rcpp::XPtr<GPB::
     int n = d->value_count();
     Rcpp::CharacterVector res(n);
     for (int i = 0; i < n; i++) {
-        res[i] = d->value(i)->name();
+        res[i] = std::string(d->value(i)->name());
     }
     return res;
 }
@@ -127,7 +127,7 @@ RPB_FUNCTION_1(S4_FileDescriptor, METHOD(fileDescriptor), Rcpp::XPtr<GPB::EnumDe
 }
 
 RPB_FUNCTION_2(std::string, METHOD(name), Rcpp::XPtr<GPB::EnumDescriptor> d, bool full) {
-    return full ? d->full_name() : d->name();
+    return std::string(full ? d->full_name() : d->name());
 }
 
 #undef METHOD

--- a/src/wrapper_EnumValueDescriptor.cpp
+++ b/src/wrapper_EnumValueDescriptor.cpp
@@ -35,7 +35,7 @@ RPB_FUNCTION_1(S4_Message, METHOD(as_Message), Rcpp::XPtr<GPB::EnumValueDescript
 }
 
 RPB_FUNCTION_2(std::string, METHOD(name), Rcpp::XPtr<GPB::EnumValueDescriptor> d, bool full) {
-    return full ? d->full_name() : d->name();
+    return std::string(full ? d->full_name() : d->name());
 }
 
 RPB_FUNCTION_1(int, METHOD(number), Rcpp::XPtr<GPB::EnumValueDescriptor> d) { return d->number(); }

--- a/src/wrapper_FieldDescriptor.cpp
+++ b/src/wrapper_FieldDescriptor.cpp
@@ -93,7 +93,7 @@ RPB_FUNCTION_1(S4_FileDescriptor, METHOD(fileDescriptor), Rcpp::XPtr<GPB::FieldD
 }
 
 RPB_FUNCTION_2(std::string, METHOD(name), Rcpp::XPtr<GPB::FieldDescriptor> d, bool full) {
-    return full ? d->full_name() : d->name();
+    return std::string(full ? d->full_name() : d->name());
 }
 
 #undef RPB_HANDLE_CASE

--- a/src/wrapper_FileDescriptor.cpp
+++ b/src/wrapper_FileDescriptor.cpp
@@ -26,25 +26,25 @@ RPB_FUNCTION_1(Rcpp::CharacterVector, METHOD(getMemberNames),
     int i = 0;
     int j = 0;
     while (i < ntypes) {
-        res[j] = desc->message_type(i)->name();
+        res[j] = std::string(desc->message_type(i)->name());
         i++;
         j++;
     }
     i = 0;
     while (i < nenums) {
-        res[j] = desc->enum_type(i)->name();
+        res[j] = std::string(desc->enum_type(i)->name());
         i++;
         j++;
     }
     i = 0;
     while (i < nserv) {
-        res[j] = desc->service(i)->name();
+        res[j] = std::string(desc->service(i)->name());
         i++;
         j++;
     }
     i = 0;
     while (i < nexts) {
-        res[j] = desc->extension(i)->name();
+        res[j] = std::string(desc->extension(i)->name());
         i++;
         j++;
     }
@@ -67,27 +67,27 @@ RPB_FUNCTION_1(Rcpp::List, METHOD(as_list), Rcpp::XPtr<GPB::FileDescriptor> desc
     int count = 0;
     for (int i = 0; i < ntypes; count++, i++) {
         res[count] = S4_Descriptor(desc->message_type(i));
-        names[count] = desc->message_type(i)->name();
+        names[count] = std::string(desc->message_type(i)->name());
     }
     for (int i = 0; i < nenums; count++, i++) {
         res[count] = S4_EnumDescriptor(desc->enum_type(i));
-        names[count] = desc->enum_type(i)->name();
+        names[count] = std::string(desc->enum_type(i)->name());
     }
     for (int i = 0; i < nserv; count++, i++) {
         res[count] = S4_ServiceDescriptor(desc->service(i));
-        names[count] = desc->service(i)->name();
+        names[count] = std::string(desc->service(i)->name());
     }
     for (int i = 0; i < nexts; count++, i++) {
         res[count] = S4_FieldDescriptor(desc->extension(i));
         // always use full names for extensions
-        names[count] = desc->extension(i)->full_name();
+        names[count] = std::string(desc->extension(i)->full_name());
     }
     res.names() = names;
     return res;
 }
 
 RPB_FUNCTION_1(std::string, METHOD(name), Rcpp::XPtr<GPB::FileDescriptor> desc) {
-    return desc->name();
+    return std::string(desc->name());
 }
 
 #undef METHOD

--- a/src/wrapper_Message.cpp
+++ b/src/wrapper_Message.cpp
@@ -190,7 +190,7 @@ RPB_FUNCTION_1(Rcpp::List, METHOD(as_list), Rcpp::XPtr<GPB::Message> message) {
     for (int i = 0; i < nf; i++) {
         const GPB::FieldDescriptor* fd = desc->field(i);
         val[i] = getMessageField(message, Rcpp::CharacterVector::create(fd->name()));
-        fieldNames[i] = fd->name();
+        fieldNames[i] = std::string(fd->name());
     }
     val.names() = fieldNames;
     return val;
@@ -430,7 +430,7 @@ RPB_FUNCTION_1(Rcpp::CharacterVector, METHOD(fieldNames), Rcpp::XPtr<GPB::Messag
     int nfields = desc->field_count();
     Rcpp::CharacterVector res(nfields);
     for (int i = 0; i < nfields; i++) {
-        res[i] = desc->field(i)->name();
+        res[i] = std::string(desc->field(i)->name());
     }
     return (res);
 }

--- a/src/wrapper_MethodDescriptor.cpp
+++ b/src/wrapper_MethodDescriptor.cpp
@@ -47,7 +47,7 @@ RPB_FUNCTION_2(bool, valid_output_message, Rcpp::XPtr<GPB::MethodDescriptor> met
 }
 
 RPB_FUNCTION_2(std::string, METHOD(name), Rcpp::XPtr<GPB::MethodDescriptor> d, bool full) {
-    return full ? d->full_name() : d->name();
+    return std::string(full ? d->full_name() : d->name());
 }
 
 #undef METHOD

--- a/src/wrapper_ServiceDescriptor.cpp
+++ b/src/wrapper_ServiceDescriptor.cpp
@@ -21,7 +21,7 @@ RPB_FUNCTION_1(Rcpp::CharacterVector, METHOD(getMethodNames),
     Rcpp::CharacterVector res(nmeths);
 
     for (int i = 0; i < nmeths; i++) {
-        res[i] = desc->method(i)->name();
+        res[i] = std::string(desc->method(i)->name());
     }
     return res;
 }
@@ -38,7 +38,7 @@ RPB_FUNCTION_1(Rcpp::List, METHOD(as_list), Rcpp::XPtr<GPB::ServiceDescriptor> d
     for (int i = 0; i < n; i++) {
         const GPB::MethodDescriptor* met = desc->method(i);
         res[i] = S4_MethodDescriptor(met);
-        names[i] = met->name();
+        names[i] = std::string(met->name());
     }
     res.names() = names;
     return res;
@@ -55,7 +55,7 @@ RPB_FUNCTION_1(S4_FileDescriptor, METHOD(fileDescriptor), Rcpp::XPtr<GPB::Servic
 }
 
 RPB_FUNCTION_2(std::string, METHOD(name), Rcpp::XPtr<GPB::ServiceDescriptor> d, bool full) {
-    return full ? d->full_name() : d->name();
+    return std::string(full ? d->full_name() : d->name());
 }
 
 /**


### PR DESCRIPTION
Prepares code for a breaking change in Protobuf C++ API. Protobuf 6.30.0 will change the return types of `Descriptor::name()` and other methods to `absl::string_view`. This makes the code work both before and after such a change.