### PR TITLE
Fix incorrect bindings for enum value descriptors

### DIFF
--- a/R/00classes.R
+++ b/R/00classes.R
@@ -550,7 +550,7 @@ function(object, full = FALSE){
 })
 setMethod( "name", c( object = "EnumValueDescriptor" ) ,
 function(object, full = FALSE){
-	.Call( EnumDescriptor__name, object@pointer, full )
+	.Call( EnumValueDescriptor__name, object@pointer, full )
 })
 setMethod( "name", c( object = "ServiceDescriptor" ) ,
 function(object, full = FALSE){

--- a/src/init.c
+++ b/src/init.c
@@ -71,6 +71,7 @@ extern SEXP EnumDescriptor__value_count(SEXP);
 extern SEXP EnumValueDescriptor__as_character(SEXP);
 extern SEXP EnumValueDescriptor__as_Message(SEXP);
 extern SEXP EnumValueDescriptor__enum_type(SEXP);
+extern SEXP EnumValueDescriptor__name(SEXP);
 extern SEXP EnumValueDescriptor__number(SEXP);
 extern SEXP FieldDescriptor__as_character(SEXP);
 extern SEXP FieldDescriptor__as_Message(SEXP);
@@ -227,6 +228,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"EnumValueDescriptor__as_character",        (DL_FUNC) &EnumValueDescriptor__as_character,         1},
     {"EnumValueDescriptor__as_Message",          (DL_FUNC) &EnumValueDescriptor__as_Message,           1},
     {"EnumValueDescriptor__enum_type",           (DL_FUNC) &EnumValueDescriptor__enum_type,            1},
+    {"EnumValueDescriptor__name",                (DL_FUNC) &EnumValueDescriptor__name,                 1},
     {"EnumValueDescriptor__number",              (DL_FUNC) &EnumValueDescriptor__number,               1},
     {"FieldDescriptor__as_character",            (DL_FUNC) &FieldDescriptor__as_character,             1},
     {"FieldDescriptor__as_Message",              (DL_FUNC) &FieldDescriptor__as_Message,               1},


### PR DESCRIPTION
This happens to work today because the memory layout of EnumDescriptor and EnumValueDescriptor match.  If this changes (which it will in a coming release), this results in memory corruption and UB.