### PR TITLE
Register ServiceDescriptor method accessors, fix method_count lookup

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2026-08-14  Troy Hernandez  <troy@cornball.ai>
+
+	* src/init.c: Register the ServiceDescriptor method_count, length,
+	getMethodByIndex, and getMethodByName routines (fixes #116)
+	* src/wrapper_ServiceDescriptor.cpp: Bounds-checked getMethodByIndex
+	and getMethodByName returning NULL on a miss, following the
+	EnumDescriptor accessors
+	* src/rprotobuf.h: Correct stale single-underscore declarations
+	* R/wrapper_ServiceDescriptor.R: method_count calls the registered
+	routine; method() resolves by index (1-based) or by name
+	* R/00classes.R: length() of a ServiceDescriptor calls the
+	registered routine
+	* inst/tinytest/test_servicedescriptor.R: New tests for the
+	ServiceDescriptor method accessors
+
 2026-08-05  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/R/00classes.R
+++ b/R/00classes.R
@@ -514,7 +514,7 @@ setMethod( "length", "EnumDescriptor", function( x ){
 	.Call( EnumDescriptor__length, x@pointer )
 } )
 setMethod( "length", "ServiceDescriptor", function( x ){
-	.Call("ServiceDescriptor_method_count", x@pointer )
+	.Call( ServiceDescriptor__length, x@pointer )
 } )
 # }}}
 

--- a/R/wrapper_ServiceDescriptor.R
+++ b/R/wrapper_ServiceDescriptor.R
@@ -2,7 +2,7 @@ setGeneric( "method_count", function(object ){
 	standardGeneric( "method_count" )
 } )
 setMethod( "method_count", "ServiceDescriptor", function(object){
-	.Call("ServiceDescriptor_method_count", object@pointer)
+	.Call(ServiceDescriptor__method_count, object@pointer)
 } )
 
 
@@ -19,11 +19,13 @@ setMethod( "method", "ServiceDescriptor", function(object, index, name){
 	}
 
 	if( has_index ){
-		stop( "No routine for getting a method from a ServiceDescriptor by index." )
+		stopifnot(is.numeric(index))
+		return( .Call(ServiceDescriptor__getMethodByIndex, object@pointer, as.integer(index)-1L) )
 	}
 
 	if( has_name ){
-		stop( "No routine for getting a method from a ServiceDescriptor by name." )
+		stopifnot(is.character(name))
+		return( .Call(ServiceDescriptor__getMethodByName, object@pointer, as.character(name)) )
 	}
 
 } )

--- a/inst/tinytest/test_servicedescriptor.R
+++ b/inst/tinytest/test_servicedescriptor.R
@@ -1,0 +1,53 @@
+# Copyright 2026 Troy Hernandez
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+library(RProtoBuf)
+
+readProtoFiles2("helloworld.proto",
+                protoPath = system.file("proto", package = "RProtoBuf"))
+
+fd <- fileDescriptor(P("rprotobuf.HelloWorldRequest"))
+svc <- fd$HelloWorldService
+expect_true(inherits(svc, "ServiceDescriptor"))
+
+# method_count and length (issue #116: the .Call target was misnamed)
+expect_equal(method_count(svc), 1L)
+expect_equal(length(svc), 1L)
+
+# method by index, 1-based as elsewhere (issue #116: routine compiled
+# but unregistered)
+m <- method(svc, index = 1L)
+expect_true(inherits(m, "MethodDescriptor"))
+expect_equal(name(m), "HelloWorld")
+
+# method by name
+m2 <- method(svc, name = "HelloWorld")
+expect_true(inherits(m2, "MethodDescriptor"))
+expect_equal(name(m2, full = TRUE), "rprotobuf.HelloWorldService.HelloWorld")
+
+# downstream MethodDescriptor accessors work from either path
+expect_equal(name(input_type(m)), "HelloWorldRequest")
+expect_equal(name(output_type(m)), "HelloWorldResponse")
+
+# out of range / unknown name give NULL, as the EnumDescriptor
+# accessors do
+expect_null(method(svc, index = 2L))
+expect_null(method(svc, index = 0L))
+expect_null(method(svc, name = "NoSuchMethod"))
+
+# exactly one of index or name
+expect_error(method(svc))
+expect_error(method(svc, index = 1L, name = "HelloWorld"))

--- a/src/init.c
+++ b/src/init.c
@@ -153,9 +153,12 @@ extern SEXP ServiceDescriptor__as_character(SEXP);
 extern SEXP ServiceDescriptor__as_list(SEXP);
 extern SEXP ServiceDescriptor__as_Message(SEXP);
 extern SEXP ServiceDescriptor__fileDescriptor(SEXP);
+extern SEXP ServiceDescriptor__getMethodByIndex(SEXP, SEXP);
+extern SEXP ServiceDescriptor__getMethodByName(SEXP, SEXP);
 extern SEXP ServiceDescriptor__getMethodNames(SEXP);
+extern SEXP ServiceDescriptor__length(SEXP);
+extern SEXP ServiceDescriptor__method_count(SEXP);
 extern SEXP ServiceDescriptor__name(SEXP, SEXP);
-/*extern SEXP ServiceDescriptor_method_count(SEXP);*/
 extern SEXP setMessageField(SEXP, SEXP, SEXP);
 extern SEXP update_message(SEXP, SEXP);
 extern SEXP valid_input_message(SEXP, SEXP);
@@ -308,9 +311,12 @@ static const R_CallMethodDef CallEntries[] = {
     {"ServiceDescriptor__as_list",               (DL_FUNC) &ServiceDescriptor__as_list,                1},
     {"ServiceDescriptor__as_Message",            (DL_FUNC) &ServiceDescriptor__as_Message,             1},
     {"ServiceDescriptor__fileDescriptor",        (DL_FUNC) &ServiceDescriptor__fileDescriptor,         1},
+    {"ServiceDescriptor__getMethodByIndex",      (DL_FUNC) &ServiceDescriptor__getMethodByIndex,       2},
+    {"ServiceDescriptor__getMethodByName",       (DL_FUNC) &ServiceDescriptor__getMethodByName,        2},
     {"ServiceDescriptor__getMethodNames",        (DL_FUNC) &ServiceDescriptor__getMethodNames,         1},
+    {"ServiceDescriptor__length",                (DL_FUNC) &ServiceDescriptor__length,                 1},
+    {"ServiceDescriptor__method_count",          (DL_FUNC) &ServiceDescriptor__method_count,           1},
     {"ServiceDescriptor__name",                  (DL_FUNC) &ServiceDescriptor__name,                   2},
-/*    {"ServiceDescriptor_method_count",           (DL_FUNC) &ServiceDescriptor_method_count,            1},*/
     {"setMessageField",                          (DL_FUNC) &setMessageField,                           3},
     {"update_message",                           (DL_FUNC) &update_message,                            2},
     {"valid_input_message",                      (DL_FUNC) &valid_input_message,                       2},

--- a/src/rprotobuf.h
+++ b/src/rprotobuf.h
@@ -170,10 +170,10 @@ void CHECK_values_for_enum(const GPB::FieldDescriptor*, SEXP);
 void CHECK_messages(const GPB::FieldDescriptor*, SEXP);
 
 /* in wrapper_ServiceDescriptor.cpp */
-RcppExport SEXP ServiceDescriptor_length(SEXP);
-RcppExport SEXP ServiceDescriptor_method_count(SEXP);
-RcppExport SEXP ServiceDescriptor_getMethodByIndex(SEXP, SEXP);
-RcppExport SEXP ServiceDescriptor_getMethodByName(SEXP, SEXP);
+RcppExport SEXP ServiceDescriptor__length(SEXP);
+RcppExport SEXP ServiceDescriptor__method_count(SEXP);
+RcppExport SEXP ServiceDescriptor__getMethodByIndex(SEXP, SEXP);
+RcppExport SEXP ServiceDescriptor__getMethodByName(SEXP, SEXP);
 
 /* in streams.cpp */
 void ZeroCopyInputStreamWrapper_finalizer(SEXP);

--- a/src/wrapper_ServiceDescriptor.cpp
+++ b/src/wrapper_ServiceDescriptor.cpp
@@ -11,9 +11,22 @@ RPB_XP_METHOD_0(METHOD(length), GPB::ServiceDescriptor, method_count)
 RPB_XP_METHOD_0(METHOD(method_count), GPB::ServiceDescriptor, method_count)
 RPB_XP_METHOD_0(METHOD(as_character), GPB::ServiceDescriptor, DebugString)
 
-RPB_XP_METHOD_CAST_1(METHOD(getMethodByIndex), GPB::ServiceDescriptor, method, S4_MethodDescriptor)
-RPB_XP_METHOD_CAST_1_STRING(METHOD(getMethodByName), GPB::ServiceDescriptor, FindMethodByName,
-                            S4_MethodDescriptor)
+RPB_FUNCTION_2(SEXP, METHOD(getMethodByIndex), Rcpp::XPtr<GPB::ServiceDescriptor> d,
+               int index) {
+    if ((index >= 0) && (index < d->method_count())) {
+        return S4_MethodDescriptor(d->method(index));
+    } else {
+        return R_NilValue;
+    }
+}
+
+RPB_FUNCTION_2(SEXP, METHOD(getMethodByName), Rcpp::XPtr<GPB::ServiceDescriptor> d,
+               std::string name) {
+    const GPB::MethodDescriptor* descriptor = d->FindMethodByName(name);
+    if (descriptor)
+        return S4_MethodDescriptor(descriptor);
+    return R_NilValue;
+}
 
 RPB_FUNCTION_1(Rcpp::CharacterVector, METHOD(getMethodNames),
                Rcpp::XPtr<GPB::ServiceDescriptor> desc) {


### PR DESCRIPTION
Fixes #116, as offered there.

**What was broken:** `method_count()` and `length()` on a `ServiceDescriptor` called `.Call()` with a single-underscore routine name that has never existed (`ServiceDescriptor_method_count`); the compiled double-underscore routines were also missing from `init.c`'s registration table, along with `getMethodByIndex`/`getMethodByName`, so `method()` was reduced to its "No routine" stubs. Single-underscore relics (a commented-out registration row and three `rprotobuf.h` declarations with no definitions) pointed at how the mismatch crept in; they're cleaned up here.

**The fix:**

- `src/init.c`: register `ServiceDescriptor__method_count`, `__length`, `__getMethodByIndex`, `__getMethodByName`.
- `src/wrapper_ServiceDescriptor.cpp`: the two accessors previously defined via the CAST macros (never callable, so no behavior change) are now explicit bounds-checked functions returning `R_NilValue` on an out-of-range index or unknown name, following the `EnumDescriptor__getValueBy*` pattern — protobuf's `ServiceDescriptor::method(int)` does not range-check in release builds.
- `R/wrapper_ServiceDescriptor.R` / `R/00classes.R`: native-symbol `.Call`s, matching the rest of the package; `method(svc, index=)` is 1-based like `value(enum, index=)`, `method(svc, name=)` resolves by name.
- `inst/tinytest/test_servicedescriptor.R`: new tests against the shipped `helloworld.proto` (`HelloWorldService`): count/length, by-index, by-name, downstream `input_type`/`output_type`, NULL on miss, and the exactly-one-of-index-or-name error.

**Verification:** full tinytest suite passes with the patch (1252 results, including the 14 new ones), and the issue's repro now returns `method_count(svc) == 1`, `name(method(svc, index = 1L), full = TRUE) == "demo.Echo.Say"`, and `NULL` for an out-of-range index. Built against protobuf 3.21.12 on Ubuntu noble.